### PR TITLE
fix: address soundness findings from internal audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,40 @@
+# Changelog
+
+## [Unreleased]
+
+## [0.2.0] - 2026-05-01
+
+### Security
+
+Soundness fixes from an internal audit of the FFI layer. Full technical
+detail and reproducers will be published in a coordinated security
+advisory once 0.2.0 is on crates.io. Versions 0.1.0–0.1.4 will be
+yanked at that time. Users on those versions should upgrade.
+
+### Changed (breaking)
+
+- `StreamingDecoder` is now `StreamingDecoder<'a>`. The `'a` parameter
+  ties a buffer-backed decoder to the buffer's lifetime so the borrow
+  checker rejects use-after-free patterns. `StreamingDecoder::new()`
+  returns `StreamingDecoder<'static>`, so call sites that don't use
+  `with_buffer` compile unchanged. `StreamingDecoder` no longer
+  auto-implements `UnwindSafe` / `RefUnwindSafe` as a side effect
+  (9580751).
+- `AnimationDecoder::with_options` now returns `Err` for color modes
+  that libwebp's animation decoder cannot satisfy
+  (`ColorMode::Rgb`, `Bgr`, `Argb`). Previously the constructor
+  accepted these and `WebPAnimDecoderNew` later returned NULL with
+  no explanation (9580751).
+
+### Fixed
+
+- Encoder: zero-copy ARGB and YUV-with-alpha paths now keep their
+  input buffers strictly read-only end-to-end (9580751).
+- `AnimationDecoder::next_frame`: frame buffer length now derives
+  from the configured color mode rather than a hard-coded value
+  (9580751).
+- `ImageInfo::from_webp`: features are only treated as initialized
+  after `WebPGetFeatures` reports success (9580751).
+- `decode_advanced`: defensive `WebPFreeDecBuffer` on the error
+  path; output slice length now uses libwebp's reported allocation
+  size rather than a recomputed value (9580751).

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webpx"
-version = "0.1.4"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -11,7 +11,8 @@ use whereat::*;
 #[derive(Debug, Clone)]
 #[non_exhaustive]
 pub struct Frame {
-    /// Frame pixel data (RGBA).
+    /// Frame pixel data, in whichever color mode the decoder was configured
+    /// with (defaults to RGBA, 4 bytes per pixel).
     pub data: Vec<u8>,
     /// Frame width.
     pub width: u32,
@@ -62,6 +63,7 @@ pub struct AnimationInfo {
 pub struct AnimationDecoder {
     decoder: *mut libwebp_sys::WebPAnimDecoder,
     info: AnimationInfo,
+    bpp: usize,
     _data: Vec<u8>, // Keep data alive
 }
 
@@ -82,15 +84,17 @@ impl AnimationDecoder {
     /// * `color_mode` - Output color format
     /// * `use_threads` - Enable multi-threaded decoding
     pub fn with_options(data: &[u8], color_mode: ColorMode, use_threads: bool) -> Result<Self> {
-        let csp_mode = match color_mode {
-            ColorMode::Rgba => libwebp_sys::WEBP_CSP_MODE::MODE_RGBA,
-            ColorMode::Bgra => libwebp_sys::WEBP_CSP_MODE::MODE_BGRA,
-            ColorMode::Argb => libwebp_sys::WEBP_CSP_MODE::MODE_ARGB,
-            ColorMode::Rgb => libwebp_sys::WEBP_CSP_MODE::MODE_RGB,
-            ColorMode::Bgr => libwebp_sys::WEBP_CSP_MODE::MODE_BGR,
+        // libwebp's WebPAnimDecoder only accepts MODE_RGBA / MODE_BGRA
+        // (and the premultiplied variants, which webpx doesn't expose).
+        // Reject anything else with a clear error rather than passing it
+        // through and letting `WebPAnimDecoderNew` return NULL with no
+        // explanation.
+        let (csp_mode, bpp) = match color_mode {
+            ColorMode::Rgba => (libwebp_sys::WEBP_CSP_MODE::MODE_RGBA, 4),
+            ColorMode::Bgra => (libwebp_sys::WEBP_CSP_MODE::MODE_BGRA, 4),
             _ => {
                 return Err(at!(Error::InvalidInput(
-                    "animation decoder only supports RGB modes".into(),
+                    "animation decoder only supports ColorMode::Rgba or ColorMode::Bgra".into(),
                 )));
             }
         };
@@ -139,6 +143,7 @@ impl AnimationDecoder {
                 loop_count: anim_info.loop_count,
                 bgcolor: anim_info.bgcolor,
             },
+            bpp,
             _data: data_copy,
         })
     }
@@ -173,8 +178,11 @@ impl AnimationDecoder {
             )));
         }
 
-        // Copy the frame data (buffer is owned by decoder)
-        let size = (self.info.width as usize) * (self.info.height as usize) * 4;
+        // Copy the frame data (buffer is owned by decoder).
+        // Buffer size matches the configured color mode (3 bpp for RGB/BGR,
+        // 4 bpp otherwise) — using a hard-coded 4 here would over-read by
+        // ~33% for the 3-bpp modes.
+        let size = (self.info.width as usize) * (self.info.height as usize) * self.bpp;
         let data = unsafe { core::slice::from_raw_parts(buf, size).to_vec() };
 
         // Calculate duration (difference from previous frame)

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -865,6 +865,11 @@ impl<'a> Decoder<'a> {
         };
 
         if status != libwebp_sys::VP8StatusCode::VP8_STATUS_OK {
+            // libwebp's internal WebPDecode frees its own buffer on failure,
+            // but call WebPFreeDecBuffer defensively — it is a safe no-op when
+            // private_memory is null and protects against future libwebp paths
+            // that might leave the buffer allocated.
+            unsafe { libwebp_sys::WebPFreeDecBuffer(&mut dec_config.output) };
             return Err(at!(Error::DecodeFailed(DecodingError::from(status as i32))));
         }
 
@@ -885,16 +890,16 @@ impl<'a> Decoder<'a> {
             dec_config.input.height as u32
         };
 
-        let bpp = match mode {
-            libwebp_sys::WEBP_CSP_MODE::MODE_RGB | libwebp_sys::WEBP_CSP_MODE::MODE_BGR => 3,
-            _ => 4,
-        };
-
-        let size = (width as usize) * (height as usize) * bpp;
+        // Use libwebp's reported allocation size rather than recomputing it
+        // from width*height*bpp. The recomputed size assumes a tightly-packed
+        // stride, which is currently the case but not guaranteed — and a
+        // mismatch would make the slice over-read libwebp's allocation.
         let pixels = unsafe {
             if dec_config.output.u.RGBA.rgba.is_null() {
+                libwebp_sys::WebPFreeDecBuffer(&mut dec_config.output);
                 return Err(at!(Error::DecodeFailed(DecodingError::OutOfMemory)));
             }
+            let size = dec_config.output.u.RGBA.size;
             let slice = core::slice::from_raw_parts(dec_config.output.u.RGBA.rgba, size);
             let vec = slice.to_vec();
             libwebp_sys::WebPFreeDecBuffer(&mut dec_config.output);

--- a/src/encode.rs
+++ b/src/encode.rs
@@ -282,6 +282,26 @@ enum EncoderInput<'a> {
     Yuv(YuvPlanesRef<'a>),
 }
 
+impl EncoderInput<'_> {
+    /// Returns true when this input variant points libwebp at user-borrowed
+    /// memory and therefore needs `WebPConfig.exact = 1` to suppress
+    /// libwebp's transparent-area cleanup writes (which would mutate the
+    /// borrowed buffer and violate Rust's aliasing model).
+    fn requires_exact(&self) -> bool {
+        match self {
+            EncoderInput::Argb { .. } => true,
+            EncoderInput::Yuv(planes) => planes.a.is_some(),
+            // The Rgba/Bgra/Rgb/Bgr variants go through WebPPictureImport*,
+            // which copies into a libwebp-allocated argb buffer that libwebp
+            // is then free to mutate.
+            EncoderInput::Rgba { .. }
+            | EncoderInput::Bgra { .. }
+            | EncoderInput::Rgb { .. }
+            | EncoderInput::Bgr { .. } => false,
+        }
+    }
+}
+
 impl<'a> Encoder<'a> {
     /// Create a new encoder for contiguous RGBA data.
     ///
@@ -434,6 +454,13 @@ impl<'a> Encoder<'a> {
     /// Create a new encoder for YUV planar data (zero-copy).
     ///
     /// The YUV planes are borrowed directly without copying.
+    ///
+    /// # Note on `exact`
+    ///
+    /// When the YUV input includes an alpha plane, `EncoderConfig.exact`
+    /// is forced to `true` regardless of the configured value, so libwebp
+    /// will not write back to the borrowed Y/U/V planes when smoothing
+    /// fully-transparent regions. YUV-without-alpha is unaffected.
     #[must_use]
     pub fn new_yuv(planes: YuvPlanesRef<'a>) -> Self {
         let width = planes.width;
@@ -460,6 +487,14 @@ impl<'a> Encoder<'a> {
     /// - Bits 16-23: Red
     /// - Bits 8-15: Green
     /// - Bits 0-7: Blue
+    ///
+    /// # Note on `exact`
+    ///
+    /// To keep the input buffer read-only from C, `EncoderConfig.exact` is
+    /// forced to `true` for this path regardless of the configured value.
+    /// This disables libwebp's optimization that overwrites RGB values
+    /// under fully-transparent pixels — a small compression cost in
+    /// exchange for keeping the borrow safe.
     ///
     /// # Example
     ///
@@ -727,7 +762,16 @@ impl<'a> Encoder<'a> {
         // Check for early cancellation
         stop.check().map_err(|reason| at!(Error::Stopped(reason)))?;
 
-        let webp_config = self.config.to_libwebp()?;
+        let mut webp_config = self.config.to_libwebp()?;
+
+        // Zero-copy paths point libwebp at user-borrowed memory. With
+        // `config.exact == 0`, libwebp's `WebPCleanupTransparentArea` /
+        // `WebPReplaceTransparentPixels` write into that memory, which
+        // would be UB given the borrow is shared from Rust's POV. Force
+        // exact=1 on the zero-copy paths so the buffer stays read-only.
+        if self.data.requires_exact() {
+            webp_config.exact = 1;
+        }
 
         // Initialize picture
         let mut picture = libwebp_sys::WebPPicture::new()
@@ -912,7 +956,12 @@ impl<'a> Encoder<'a> {
         // Check for early cancellation
         stop.check().map_err(|reason| at!(Error::Stopped(reason)))?;
 
-        let webp_config = self.config.to_libwebp()?;
+        let mut webp_config = self.config.to_libwebp()?;
+        // See `Encoder::encode` — zero-copy inputs need exact=1 to keep
+        // libwebp from writing through borrowed user memory.
+        if self.data.requires_exact() {
+            webp_config.exact = 1;
+        }
 
         // Initialize picture
         let mut picture = libwebp_sys::WebPPicture::new()

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -3,6 +3,7 @@
 use crate::error::{DecodingError, Error, Result};
 use crate::types::ColorMode;
 use alloc::vec::Vec;
+use core::marker::PhantomData;
 use core::ptr;
 use whereat::*;
 
@@ -50,19 +51,26 @@ pub enum DecodeStatus {
 /// let (pixels, width, height) = decoder.finish()?;
 /// # Ok::<(), webpx::At<webpx::Error>>(())
 /// ```
-pub struct StreamingDecoder {
+pub struct StreamingDecoder<'a> {
     decoder: *mut libwebp_sys::WebPIDecoder,
     color_mode: ColorMode,
     width: i32,
     height: i32,
     last_y: i32,
+    // Ties the decoder's lifetime to the caller-supplied output buffer
+    // (when `with_buffer` is used). For `new()` the lifetime is `'static`
+    // because libwebp owns the buffer.
+    _marker: PhantomData<&'a mut [u8]>,
 }
 
 // SAFETY: The WebPIDecoder is internally thread-safe for single-threaded access
-unsafe impl Send for StreamingDecoder {}
+unsafe impl Send for StreamingDecoder<'_> {}
 
-impl StreamingDecoder {
+impl StreamingDecoder<'static> {
     /// Create a new streaming decoder.
+    ///
+    /// libwebp allocates and owns the output buffer for this constructor;
+    /// the returned decoder has no lifetime constraints on the caller.
     ///
     /// # Arguments
     ///
@@ -97,10 +105,19 @@ impl StreamingDecoder {
             width: 0,
             height: 0,
             last_y: 0,
+            _marker: PhantomData,
         })
     }
+}
 
+impl<'a> StreamingDecoder<'a> {
     /// Create a streaming decoder with a pre-allocated output buffer.
+    ///
+    /// The decoder borrows `output_buffer` for its entire lifetime — libwebp
+    /// stores the raw pointer internally and writes into it on every
+    /// `append` / `update` / `get_partial` / `finish` call. The lifetime
+    /// parameter ties the returned decoder to the buffer so the borrow
+    /// checker rejects code that drops the buffer before the decoder.
     ///
     /// # Arguments
     ///
@@ -108,7 +125,7 @@ impl StreamingDecoder {
     /// * `stride` - Row stride in bytes
     /// * `color_mode` - Output color format
     pub fn with_buffer(
-        output_buffer: &mut [u8],
+        output_buffer: &'a mut [u8],
         stride: usize,
         color_mode: ColorMode,
     ) -> Result<Self> {
@@ -144,6 +161,7 @@ impl StreamingDecoder {
             width: 0,
             height: 0,
             last_y: 0,
+            _marker: PhantomData,
         })
     }
 
@@ -296,7 +314,7 @@ impl StreamingDecoder {
     }
 }
 
-impl Drop for StreamingDecoder {
+impl Drop for StreamingDecoder<'_> {
     fn drop(&mut self) {
         if !self.decoder.is_null() {
             unsafe {

--- a/src/types.rs
+++ b/src/types.rs
@@ -229,18 +229,20 @@ impl ImageInfo {
             return Err(at!(crate::Error::InvalidWebP));
         }
 
-        // Get more detailed features
+        // Get more detailed features. Only `assume_init` after `WebPGetFeatures`
+        // returns `VP8_STATUS_OK` — on failure libwebp may not have written all
+        // fields, and `MaybeUninit::assume_init` on uninitialized memory is UB
+        // even for plain integer structs.
         let mut features = core::mem::MaybeUninit::<libwebp_sys::WebPBitstreamFeatures>::uninit();
         let status = unsafe {
             libwebp_sys::WebPGetFeatures(data.as_ptr(), data.len(), features.as_mut_ptr())
         };
-        let features = unsafe { features.assume_init() };
-
         if status != libwebp_sys::VP8StatusCode::VP8_STATUS_OK {
             return Err(at!(crate::Error::DecodeFailed(
                 crate::error::DecodingError::from(status as i32),
             )));
         }
+        let features = unsafe { features.assume_init() };
 
         let format = match features.format {
             0 => BitstreamFormat::Undefined,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2389,6 +2389,49 @@ mod animation_tests {
     }
 
     #[test]
+    fn test_animation_decoder_rejects_unsupported_modes() {
+        // Regression: webpx previously accepted Rgb/Bgr/Argb at the API
+        // surface, then libwebp returned NULL inside WebPAnimDecoderNew
+        // with no explanation. We now reject those modes up-front. The
+        // hard-coded 4-bpp size in next_frame was tied to this — see the
+        // companion fix in src/animation.rs that derives bpp from the
+        // configured color mode.
+        use webpx::{AnimationDecoder, AnimationEncoder, ColorMode};
+
+        let width = 16;
+        let height = 16;
+        let frame1 = generate_rgba(width, height, 100, 150, 200, 255);
+        let frame2 = generate_rgba(width, height, 200, 150, 100, 255);
+
+        let mut encoder = AnimationEncoder::new(width, height).expect("encoder");
+        encoder.add_frame_rgba(&frame1, 0).expect("add");
+        encoder.add_frame_rgba(&frame2, 100).expect("add");
+        let webp = encoder.finish(200).expect("finish");
+
+        for mode in [ColorMode::Rgb, ColorMode::Bgr, ColorMode::Argb] {
+            let result = AnimationDecoder::with_options(&webp, mode, false);
+            assert!(
+                result.is_err(),
+                "{:?} should be rejected up-front (libwebp does not support it for animations)",
+                mode
+            );
+        }
+
+        // RGBA and BGRA both produce 4-bpp frame buffers.
+        for mode in [ColorMode::Rgba, ColorMode::Bgra] {
+            let mut decoder = AnimationDecoder::with_options(&webp, mode, false).expect("decoder");
+            let decoded = decoder.next_frame().expect("next").expect("frame");
+            let expected = (width * height) as usize * 4;
+            assert_eq!(
+                decoded.data.len(),
+                expected,
+                "wrong buffer length for {:?}",
+                mode
+            );
+        }
+    }
+
+    #[test]
     fn test_animation_decoder_yuv_error() {
         use webpx::{AnimationDecoder, AnimationEncoder, ColorMode};
 


### PR DESCRIPTION
## Summary

Fixes a set of soundness findings from an internal audit of the FFI layer (`unsafe` blocks across `encode`, `decode`, `streaming`, `animation`).

Full technical details and reproducers are held back until the patch release ships and a coordinated security advisory is published. This stub will be updated with the full writeup at that point. The diff itself remains visible — the fixes are conservative and the test suite covers them — but specifics of the exploitable patterns are deferred.

## Scope

- One public API change: `StreamingDecoder` gains a lifetime parameter (`'a`), wired so existing call sites that don't use `with_buffer` compile unchanged.
- Defensive cleanups in `decode_advanced` and `ImageInfo::from_webp`.
- `AnimationDecoder` constructor now rejects color modes that libwebp's animation decoder cannot satisfy.
- Internal `WebPConfig` adjustments on the zero-copy encoder paths.

## Test Plan

- [x] `cargo test --all-features` — 25 unit + 180 integration + 32 doctests
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] Added `test_animation_decoder_rejects_unsupported_modes`

## Disclosure

A RustSec advisory and crates.io yanks for the affected versions will follow once the patch release is on crates.io.

🤖 Generated with [Claude Code](https://claude.com/claude-code)