### PR TITLE
feat: Limits resource policy (max_pixels, max_total_pixels, max_metadata_bytes, ...)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,47 @@
 
 ## [Unreleased]
 
+### Added
+
+- `webpx::Limits` — opt-in resource policy modeled on
+  `zencodec::ResourceLimits`. Fields: `max_pixels` (per-frame),
+  `max_total_pixels` (across all animation frames),
+  `max_width`, `max_height`, `max_input_bytes`, `max_frames`,
+  `max_animation_ms`, `max_metadata_bytes`, `max_output_bytes`.
+  All `Option<T>`; `None` means no webpx-side cap.
+- `webpx::LimitExceeded` — error variant carrying the actual value
+  and the limit that was exceeded. Returned via the new
+  `Error::LimitExceeded` variant, also implements
+  `core::error::Error` standalone.
+- `DecoderConfig::limits(Limits)` and `::get_limits()` — apply the
+  policy at parse time. `max_width`, `max_height`, `max_pixels`, and
+  `max_total_pixels` are checked via `WebPGetFeatures` before
+  libwebp allocates the output buffer; if `scale()` is also set,
+  the post-scale dimensions are checked too.
+- `AnimationDecoder::with_options_limits(data, mode, threads, &Limits)`
+  — applies limits against the canvas dimensions and declared
+  `frame_count` before any decode work. `max_total_pixels`
+  catches the W × H × N animation-bomb case that per-frame
+  `max_pixels` misses. Closes [#4].
+- `mux::get_icc_profile_with_limits` / `get_exif_with_limits` /
+  `get_xmp_with_limits` — apply `Limits::max_metadata_bytes` on
+  top of the existing 256 MiB internal hard cap.
+
 ### Changed (breaking)
 
+- `EncoderConfig` and `DecoderConfig` are now `#[non_exhaustive]`.
+  They have `pub(crate)` fields so external struct-literal
+  construction was already disallowed; the marker documents that
+  these structs will grow (`limits`, future config knobs) without
+  another minor bump.
 - `error::EncodingError`, `error::DecodingError`, `error::MuxError`
   and `types::ImageInfo` are now `#[non_exhaustive]`. Match arms must
   add `_ =>` and struct construction must go through a constructor.
   This closes the door on adding new libwebp error variants or new
   bitstream-info fields requiring another minor bump.
+- `Error` gains a `LimitExceeded(LimitExceeded)` variant. Already
+  `#[non_exhaustive]`, so adding the variant is a non-breaking
+  additive change for `match` arms with `_ =>`.
 
 ### Fixed
 
@@ -21,6 +55,7 @@
   Closes [#1].
 
 [#1]: https://github.com/imazen/webpx/issues/1
+[#4]: https://github.com/imazen/webpx/issues/4
 
 ## [0.2.0] - 2026-05-01
 

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -78,12 +78,39 @@ impl AnimationDecoder {
 
     /// Create a new animation decoder with options.
     ///
+    /// Equivalent to [`Self::with_options_limits`] with [`crate::Limits::none`].
+    ///
     /// # Arguments
     ///
     /// * `data` - WebP animation data
     /// * `color_mode` - Output color format
     /// * `use_threads` - Enable multi-threaded decoding
     pub fn with_options(data: &[u8], color_mode: ColorMode, use_threads: bool) -> Result<Self> {
+        Self::with_options_limits(data, color_mode, use_threads, &crate::Limits::none())
+    }
+
+    /// Create a new animation decoder with options and a [`crate::Limits`]
+    /// policy.
+    ///
+    /// Caps from `limits` are checked against the canvas dimensions and
+    /// declared frame count *before* the decoder is opened, so a hostile
+    /// animation declaring 16383×16383 × 100k frames is rejected up
+    /// front. `max_total_pixels` is the most useful budget here — it
+    /// catches the cumulative cost of `width × height × frame_count`
+    /// that per-frame caps miss.
+    ///
+    /// # Arguments
+    ///
+    /// * `data` - WebP animation data
+    /// * `color_mode` - Output color format
+    /// * `use_threads` - Enable multi-threaded decoding
+    /// * `limits` - Resource limits policy (use [`crate::Limits::none`] for none)
+    pub fn with_options_limits(
+        data: &[u8],
+        color_mode: ColorMode,
+        use_threads: bool,
+        limits: &crate::Limits,
+    ) -> Result<Self> {
         // libwebp's WebPAnimDecoder only accepts MODE_RGBA / MODE_BGRA
         // (and the premultiplied variants, which webpx doesn't expose).
         // Reject anything else with a clear error rather than passing it
@@ -132,6 +159,18 @@ impl AnimationDecoder {
         if ok == 0 {
             unsafe { libwebp_sys::WebPAnimDecoderDelete(decoder) };
             return Err(at!(Error::InvalidWebP));
+        }
+
+        // Apply Limits against the declared canvas + frame count *before*
+        // any decode work. `max_total_pixels` (canvas area × frame count)
+        // is the budget that catches the W×H×N animation-bomb case.
+        if let Err(e) = limits.check_animation(
+            anim_info.canvas_width,
+            anim_info.canvas_height,
+            anim_info.frame_count,
+        ) {
+            unsafe { libwebp_sys::WebPAnimDecoderDelete(decoder) };
+            return Err(at!(Error::LimitExceeded(e)));
         }
 
         Ok(Self {

--- a/src/config.rs
+++ b/src/config.rs
@@ -198,6 +198,7 @@ impl Preset {
 /// # Ok::<(), webpx::At<webpx::Error>>(())
 /// ```
 #[derive(Debug, Clone)]
+#[non_exhaustive]
 pub struct EncoderConfig {
     pub(crate) quality: f32,
     pub(crate) preset: Preset,
@@ -993,6 +994,7 @@ impl EncoderConfig {
 
 /// Decoder configuration.
 #[derive(Debug, Clone, Default)]
+#[non_exhaustive]
 pub struct DecoderConfig {
     pub(crate) bypass_filtering: bool,
     pub(crate) no_fancy_upsampling: bool,
@@ -1007,6 +1009,8 @@ pub struct DecoderConfig {
     pub(crate) use_threads: bool,
     pub(crate) flip: bool,
     pub(crate) alpha_dithering: u8,
+    /// Resource limits applied at parse time. See [`crate::Limits`].
+    pub(crate) limits: crate::Limits,
 }
 
 impl DecoderConfig {
@@ -1071,8 +1075,51 @@ impl DecoderConfig {
         self
     }
 
+    /// Apply a [`Limits`](crate::Limits) policy to the decoder.
+    ///
+    /// Limits are checked via `WebPGetFeatures` (or the equivalent demuxer
+    /// path) *before* libwebp allocates its output buffer, so a hostile
+    /// WebP declaring an in-spec-but-huge canvas is rejected up front
+    /// rather than triggering an OOM.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// use webpx::{Decoder, DecoderConfig, Limits};
+    ///
+    /// let limits = Limits::none()
+    ///     .with_max_pixels(64 * 1024 * 1024)
+    ///     .with_max_total_pixels(256 * 1024 * 1024)
+    ///     .with_max_frames(1024);
+    ///
+    /// let webp_data: &[u8] = &[];
+    /// let config = DecoderConfig::new().limits(limits);
+    /// let img = Decoder::new(webp_data)?.config(config).decode_rgba()?;
+    /// # Ok::<(), webpx::At<webpx::Error>>(())
+    /// ```
+    #[must_use]
+    pub fn limits(mut self, limits: crate::Limits) -> Self {
+        self.limits = limits;
+        self
+    }
+
+    /// Borrow the configured [`Limits`](crate::Limits).
+    #[must_use]
+    pub fn get_limits(&self) -> &crate::Limits {
+        &self.limits
+    }
+
+    /// Apply the configured pixel-budget limits against the still-image
+    /// dimensions. Used internally by [`crate::Decoder`].
+    pub(crate) fn check_still_image(&self, width: u32, height: u32) -> Result<()> {
+        self.limits
+            .check_still_image(width, height)
+            .map_err(|e| at!(Error::LimitExceeded(e)))
+    }
+
     /// Returns true if any option requires the advanced WebPDecode API
-    /// instead of the simple WebPDecodeRGBA/etc functions.
+    /// instead of the simple WebPDecodeRGBA/etc functions. `Limits`
+    /// counts here too — the budget gates live in `decode_advanced`.
     pub(crate) fn needs_advanced_api(&self) -> bool {
         self.use_cropping
             || self.use_scaling
@@ -1081,5 +1128,6 @@ impl DecoderConfig {
             || self.no_fancy_upsampling
             || self.flip
             || self.alpha_dithering > 0
+            || self.limits.has_any()
     }
 }

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -880,6 +880,18 @@ impl<'a> Decoder<'a> {
         if status != libwebp_sys::VP8StatusCode::VP8_STATUS_OK {
             return Err(at!(Error::DecodeFailed(DecodingError::from(status as i32))));
         }
+        // Limits checks happen after features are read but before libwebp
+        // allocates the output buffer in WebPDecode. The pre-scale check
+        // is the cheap upfront gate; if a scale is configured, also check
+        // the post-scale dimensions so the produced canvas honors the cap.
+        self.config.check_still_image(
+            dec_config.input.width as u32,
+            dec_config.input.height as u32,
+        )?;
+        if self.config.use_scaling {
+            self.config
+                .check_still_image(self.config.scaled_width, self.config.scaled_height)?;
+        }
 
         // Configure output
         dec_config.output.colorspace = mode;

--- a/src/error.rs
+++ b/src/error.rs
@@ -96,6 +96,8 @@ pub enum Error {
     Stopped(StopReason),
     /// I/O error
     IoError(String),
+    /// A configured resource limit ([`Limits`](crate::Limits)) was exceeded.
+    LimitExceeded(crate::LimitExceeded),
 }
 
 impl fmt::Display for Error {
@@ -113,7 +115,14 @@ impl fmt::Display for Error {
             Error::InvalidWebP => write!(f, "invalid WebP data"),
             Error::Stopped(reason) => write!(f, "{}", reason),
             Error::IoError(msg) => write!(f, "I/O error: {}", msg),
+            Error::LimitExceeded(e) => write!(f, "limit exceeded: {}", e),
         }
+    }
+}
+
+impl From<crate::LimitExceeded> for Error {
+    fn from(e: crate::LimitExceeded) -> Self {
+        Error::LimitExceeded(e)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ whereat::define_at_crate_info!();
 
 mod config;
 pub mod error;
+mod limits;
 mod types;
 
 #[cfg(feature = "decode")]
@@ -117,6 +118,7 @@ pub mod compat;
 // Re-exports
 pub use config::{AlphaFilter, DecoderConfig, EncodeStats, EncoderConfig, ImageHint, Preset};
 pub use error::{DecodingError, EncodingError, Error, MuxError, Result};
+pub use limits::{LimitExceeded, Limits};
 pub use types::{BitstreamFormat, ColorMode, ImageInfo, WebPData, YuvPlanes, YuvPlanesRef};
 
 // Re-export enough crate types for cooperative cancellation
@@ -139,8 +141,8 @@ pub use encode::Encoder;
 
 #[cfg(feature = "icc")]
 pub use mux::{
-    embed_exif, embed_icc, embed_xmp, get_exif, get_icc_profile, get_xmp, remove_exif, remove_icc,
-    remove_xmp,
+    embed_exif, embed_icc, embed_xmp, get_exif, get_exif_with_limits, get_icc_profile,
+    get_icc_profile_with_limits, get_xmp, get_xmp_with_limits, remove_exif, remove_icc, remove_xmp,
 };
 
 #[cfg(feature = "streaming")]

--- a/src/limits.rs
+++ b/src/limits.rs
@@ -1,0 +1,489 @@
+//! Resource limits for decode/encode operations.
+//!
+//! [`Limits`] defines caps on resource usage. [`LimitExceeded`] is returned
+//! when a check fails. The shape matches `zencodec::ResourceLimits` so a
+//! caller carrying a single resource policy across multiple imazen codecs
+//! can lift the relevant fields into webpx's [`Limits`] without re-thinking
+//! the units.
+//!
+//! Use the `check_*` methods for parse-time rejection (fastest — reject
+//! before any pixel work):
+//!
+//! ```rust,no_run
+//! use webpx::{Decoder, DecoderConfig, Limits};
+//!
+//! let limits = Limits::none()
+//!     .with_max_pixels(64 * 1024 * 1024)            // 64 MP per frame
+//!     .with_max_total_pixels(256 * 1024 * 1024)     // 256 MP across all frames
+//!     .with_max_frames(1024)
+//!     .with_max_metadata_bytes(4 * 1024 * 1024);    // 4 MB ICC/EXIF/XMP
+//!
+//! let webp_data: &[u8] = &[];
+//! let img = Decoder::new(webp_data)?
+//!     .config(DecoderConfig::new().limits(limits))
+//!     .decode_rgba()?;
+//! # Ok::<(), webpx::At<webpx::Error>>(())
+//! ```
+
+/// Resource limits for decode/encode operations.
+///
+/// All fields are optional; `None` means no webpx-side limit (libwebp's
+/// intrinsic 16383×16383 cap still applies). Codecs enforce what they
+/// can — not all limit types apply to every operation.
+///
+/// Field naming matches `zencodec::ResourceLimits` so cross-codec policy
+/// objects map cleanly. Threading is intentionally not in this struct —
+/// it's a performance knob, not a DoS budget; use
+/// [`DecoderConfig::use_threads`](crate::DecoderConfig::use_threads).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct Limits {
+    /// Maximum pixels in a single frame (`width × height`).
+    ///
+    /// **Per-frame** limit. For animations, each frame is checked
+    /// independently. To bound the cumulative pixel count across all
+    /// frames, use [`max_total_pixels`](Self::max_total_pixels) too.
+    pub max_pixels: Option<u64>,
+    /// Maximum pixels across **all frames** (`width × height × frame_count`).
+    ///
+    /// A 1000×1000 animation with 200 frames has 200 million total pixels.
+    /// `max_pixels` would pass each 1 MP frame individually — this field
+    /// catches the cumulative cost.
+    pub max_total_pixels: Option<u64>,
+    /// Maximum image width in pixels.
+    pub max_width: Option<u32>,
+    /// Maximum image height in pixels.
+    pub max_height: Option<u32>,
+    /// Maximum decode input size in bytes.
+    pub max_input_bytes: Option<u64>,
+    /// Maximum number of animation frames.
+    pub max_frames: Option<u32>,
+    /// Maximum total animation duration in milliseconds.
+    pub max_animation_ms: Option<u64>,
+    /// Maximum size of an ICCP / EXIF / XMP chunk returned from the
+    /// demuxer.
+    ///
+    /// `None` means the webpx-internal hard cap (256 MiB) still applies.
+    /// `Some(n)` rejects chunks larger than `n` (and is also bounded by
+    /// the 256 MiB hard cap — a `Some` value larger than 256 MiB is
+    /// effectively the hard cap).
+    pub max_metadata_bytes: Option<u32>,
+    /// Maximum encoded output size in bytes (encode operations).
+    pub max_output_bytes: Option<u64>,
+}
+
+impl Limits {
+    /// No webpx-side limits — only libwebp's intrinsic caps apply.
+    #[must_use]
+    pub fn none() -> Self {
+        Self::default()
+    }
+
+    /// Set [`max_pixels`](Self::max_pixels).
+    #[must_use]
+    pub fn with_max_pixels(mut self, max: u64) -> Self {
+        self.max_pixels = Some(max);
+        self
+    }
+
+    /// Set [`max_total_pixels`](Self::max_total_pixels).
+    #[must_use]
+    pub fn with_max_total_pixels(mut self, max: u64) -> Self {
+        self.max_total_pixels = Some(max);
+        self
+    }
+
+    /// Set [`max_width`](Self::max_width).
+    #[must_use]
+    pub fn with_max_width(mut self, max: u32) -> Self {
+        self.max_width = Some(max);
+        self
+    }
+
+    /// Set [`max_height`](Self::max_height).
+    #[must_use]
+    pub fn with_max_height(mut self, max: u32) -> Self {
+        self.max_height = Some(max);
+        self
+    }
+
+    /// Set [`max_input_bytes`](Self::max_input_bytes).
+    #[must_use]
+    pub fn with_max_input_bytes(mut self, max: u64) -> Self {
+        self.max_input_bytes = Some(max);
+        self
+    }
+
+    /// Set [`max_frames`](Self::max_frames).
+    #[must_use]
+    pub fn with_max_frames(mut self, max: u32) -> Self {
+        self.max_frames = Some(max);
+        self
+    }
+
+    /// Set [`max_animation_ms`](Self::max_animation_ms).
+    #[must_use]
+    pub fn with_max_animation_ms(mut self, max: u64) -> Self {
+        self.max_animation_ms = Some(max);
+        self
+    }
+
+    /// Set [`max_metadata_bytes`](Self::max_metadata_bytes).
+    #[must_use]
+    pub fn with_max_metadata_bytes(mut self, max: u32) -> Self {
+        self.max_metadata_bytes = Some(max);
+        self
+    }
+
+    /// Set [`max_output_bytes`](Self::max_output_bytes).
+    #[must_use]
+    pub fn with_max_output_bytes(mut self, max: u64) -> Self {
+        self.max_output_bytes = Some(max);
+        self
+    }
+
+    /// Whether any limits are set.
+    #[must_use]
+    pub fn has_any(&self) -> bool {
+        self.max_pixels.is_some()
+            || self.max_total_pixels.is_some()
+            || self.max_width.is_some()
+            || self.max_height.is_some()
+            || self.max_input_bytes.is_some()
+            || self.max_frames.is_some()
+            || self.max_animation_ms.is_some()
+            || self.max_metadata_bytes.is_some()
+            || self.max_output_bytes.is_some()
+    }
+
+    // --- Validation methods ---
+
+    /// Check `width × height` against `max_width`, `max_height`, `max_pixels`.
+    pub fn check_dimensions(&self, width: u32, height: u32) -> Result<(), LimitExceeded> {
+        if let Some(max) = self.max_width
+            && width > max
+        {
+            return Err(LimitExceeded::Width { actual: width, max });
+        }
+        if let Some(max) = self.max_height
+            && height > max
+        {
+            return Err(LimitExceeded::Height {
+                actual: height,
+                max,
+            });
+        }
+        if let Some(max) = self.max_pixels {
+            let pixels = u64::from(width).saturating_mul(u64::from(height));
+            if pixels > max {
+                return Err(LimitExceeded::Pixels {
+                    actual: pixels,
+                    max,
+                });
+            }
+        }
+        Ok(())
+    }
+
+    /// Check input data size against `max_input_bytes`.
+    pub fn check_input_size(&self, bytes: u64) -> Result<(), LimitExceeded> {
+        if let Some(max) = self.max_input_bytes
+            && bytes > max
+        {
+            return Err(LimitExceeded::InputSize { actual: bytes, max });
+        }
+        Ok(())
+    }
+
+    /// Check encoded output size against `max_output_bytes`.
+    pub fn check_output_size(&self, bytes: u64) -> Result<(), LimitExceeded> {
+        if let Some(max) = self.max_output_bytes
+            && bytes > max
+        {
+            return Err(LimitExceeded::OutputSize { actual: bytes, max });
+        }
+        Ok(())
+    }
+
+    /// Check frame count against `max_frames`.
+    pub fn check_frames(&self, count: u32) -> Result<(), LimitExceeded> {
+        if let Some(max) = self.max_frames
+            && count > max
+        {
+            return Err(LimitExceeded::Frames { actual: count, max });
+        }
+        Ok(())
+    }
+
+    /// Check animation duration against `max_animation_ms`.
+    pub fn check_animation_ms(&self, ms: u64) -> Result<(), LimitExceeded> {
+        if let Some(max) = self.max_animation_ms
+            && ms > max
+        {
+            return Err(LimitExceeded::Duration { actual: ms, max });
+        }
+        Ok(())
+    }
+
+    /// Check total pixels across all frames against `max_total_pixels`.
+    pub fn check_total_pixels(&self, total: u64) -> Result<(), LimitExceeded> {
+        if let Some(max) = self.max_total_pixels
+            && total > max
+        {
+            return Err(LimitExceeded::TotalPixels { actual: total, max });
+        }
+        Ok(())
+    }
+
+    /// Check a metadata chunk (ICCP / EXIF / XMP) byte count against
+    /// `max_metadata_bytes`.
+    pub fn check_metadata_bytes(&self, bytes: u32) -> Result<(), LimitExceeded> {
+        if let Some(max) = self.max_metadata_bytes
+            && bytes > max
+        {
+            return Err(LimitExceeded::MetadataSize { actual: bytes, max });
+        }
+        Ok(())
+    }
+
+    /// Check a still image's `(width, height)` plus a frame count of 1
+    /// against all dimension and pixel-budget limits in one call.
+    pub fn check_still_image(&self, width: u32, height: u32) -> Result<(), LimitExceeded> {
+        self.check_dimensions(width, height)?;
+        if let Some(max) = self.max_total_pixels {
+            let total = u64::from(width).saturating_mul(u64::from(height));
+            if total > max {
+                return Err(LimitExceeded::TotalPixels { actual: total, max });
+            }
+        }
+        Ok(())
+    }
+
+    /// Check an animated image's `(width, height, frame_count)` against
+    /// `max_width`, `max_height`, `max_pixels`, `max_frames`, and
+    /// `max_total_pixels` in one call.
+    pub fn check_animation(
+        &self,
+        width: u32,
+        height: u32,
+        frame_count: u32,
+    ) -> Result<(), LimitExceeded> {
+        self.check_dimensions(width, height)?;
+        self.check_frames(frame_count)?;
+        if let Some(max) = self.max_total_pixels {
+            let total = u64::from(width)
+                .saturating_mul(u64::from(height))
+                .saturating_mul(u64::from(frame_count));
+            if total > max {
+                return Err(LimitExceeded::TotalPixels { actual: total, max });
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A resource limit was exceeded.
+///
+/// Each variant carries the actual value and the limit that was exceeded
+/// so the message can be useful. Implements [`core::error::Error`] so
+/// callers can wrap or propagate it; webpx's own [`Error`](crate::Error)
+/// already converts via the `?` operator (see `Error::LimitExceeded`).
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum LimitExceeded {
+    /// Image width exceeded `max_width`.
+    Width {
+        /// Actual width.
+        actual: u32,
+        /// Maximum allowed.
+        max: u32,
+    },
+    /// Image height exceeded `max_height`.
+    Height {
+        /// Actual height.
+        actual: u32,
+        /// Maximum allowed.
+        max: u32,
+    },
+    /// Pixel count exceeded `max_pixels`.
+    Pixels {
+        /// Actual pixel count.
+        actual: u64,
+        /// Maximum allowed.
+        max: u64,
+    },
+    /// Total pixels across all frames exceeded `max_total_pixels`.
+    TotalPixels {
+        /// Actual total pixel count (`width × height × frames`).
+        actual: u64,
+        /// Maximum allowed.
+        max: u64,
+    },
+    /// Input data size exceeded `max_input_bytes`.
+    InputSize {
+        /// Actual input size in bytes.
+        actual: u64,
+        /// Maximum allowed.
+        max: u64,
+    },
+    /// Encoded output exceeded `max_output_bytes`.
+    OutputSize {
+        /// Actual or estimated output size in bytes.
+        actual: u64,
+        /// Maximum allowed.
+        max: u64,
+    },
+    /// Frame count exceeded `max_frames`.
+    Frames {
+        /// Actual frame count.
+        actual: u32,
+        /// Maximum allowed.
+        max: u32,
+    },
+    /// Animation duration exceeded `max_animation_ms`.
+    Duration {
+        /// Actual duration in milliseconds.
+        actual: u64,
+        /// Maximum allowed.
+        max: u64,
+    },
+    /// Metadata chunk size exceeded `max_metadata_bytes`.
+    MetadataSize {
+        /// Actual chunk size in bytes.
+        actual: u32,
+        /// Maximum allowed.
+        max: u32,
+    },
+}
+
+impl core::fmt::Display for LimitExceeded {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Width { actual, max } => write!(f, "width {actual} exceeds limit {max}"),
+            Self::Height { actual, max } => write!(f, "height {actual} exceeds limit {max}"),
+            Self::Pixels { actual, max } => write!(f, "pixel count {actual} exceeds limit {max}"),
+            Self::TotalPixels { actual, max } => {
+                write!(f, "total pixels {actual} exceeds limit {max}")
+            }
+            Self::InputSize { actual, max } => {
+                write!(f, "input size {actual} bytes exceeds limit {max}")
+            }
+            Self::OutputSize { actual, max } => {
+                write!(f, "output size {actual} bytes exceeds limit {max}")
+            }
+            Self::Frames { actual, max } => write!(f, "frame count {actual} exceeds limit {max}"),
+            Self::Duration { actual, max } => {
+                write!(f, "duration {actual}ms exceeds limit {max}ms")
+            }
+            Self::MetadataSize { actual, max } => {
+                write!(f, "metadata chunk size {actual} bytes exceeds limit {max}")
+            }
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for LimitExceeded {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_has_no_limits() {
+        assert!(!Limits::none().has_any());
+    }
+
+    #[test]
+    fn builder_sets_fields() {
+        let l = Limits::none()
+            .with_max_pixels(1_000_000)
+            .with_max_total_pixels(10_000_000)
+            .with_max_metadata_bytes(4 * 1024 * 1024);
+        assert!(l.has_any());
+        assert_eq!(l.max_pixels, Some(1_000_000));
+        assert_eq!(l.max_total_pixels, Some(10_000_000));
+        assert_eq!(l.max_metadata_bytes, Some(4 * 1024 * 1024));
+    }
+
+    #[test]
+    fn check_dimensions_pass_and_fail() {
+        let l = Limits::none()
+            .with_max_width(1920)
+            .with_max_height(1080)
+            .with_max_pixels(2_073_600);
+        assert!(l.check_dimensions(1920, 1080).is_ok());
+        assert!(matches!(
+            l.check_dimensions(1921, 1080),
+            Err(LimitExceeded::Width { .. })
+        ));
+        assert!(matches!(
+            l.check_dimensions(1920, 1081),
+            Err(LimitExceeded::Height { .. })
+        ));
+    }
+
+    #[test]
+    fn check_animation_total_pixels_catches_cumulative() {
+        // 1000×1000 × 200 frames = 200M; per-frame 1M passes, total fails.
+        let l = Limits::none()
+            .with_max_pixels(2_000_000)
+            .with_max_total_pixels(100_000_000);
+        let err = l.check_animation(1000, 1000, 200).unwrap_err();
+        assert_eq!(
+            err,
+            LimitExceeded::TotalPixels {
+                actual: 200_000_000,
+                max: 100_000_000
+            }
+        );
+    }
+
+    #[test]
+    fn check_still_image_includes_total_pixels() {
+        let l = Limits::none().with_max_total_pixels(1_000_000);
+        // 1001×1000 = 1_001_000 > 1_000_000
+        let err = l.check_still_image(1001, 1000).unwrap_err();
+        assert_eq!(
+            err,
+            LimitExceeded::TotalPixels {
+                actual: 1_001_000,
+                max: 1_000_000
+            }
+        );
+    }
+
+    #[test]
+    fn check_metadata_bytes() {
+        let l = Limits::none().with_max_metadata_bytes(4096);
+        assert!(l.check_metadata_bytes(2048).is_ok());
+        assert!(matches!(
+            l.check_metadata_bytes(8192),
+            Err(LimitExceeded::MetadataSize { .. })
+        ));
+    }
+
+    #[test]
+    fn check_dimensions_no_limits_always_passes() {
+        let l = Limits::none();
+        assert!(l.check_dimensions(u32::MAX, u32::MAX).is_ok());
+    }
+
+    #[test]
+    fn limit_exceeded_display() {
+        use alloc::format;
+        let err = LimitExceeded::Width {
+            actual: 5000,
+            max: 4096,
+        };
+        assert_eq!(format!("{err}"), "width 5000 exceeds limit 4096");
+        let err = LimitExceeded::TotalPixels {
+            actual: 200_000_000,
+            max: 100_000_000,
+        };
+        assert_eq!(
+            format!("{err}"),
+            "total pixels 200000000 exceeds limit 100000000"
+        );
+    }
+}

--- a/src/mux.rs
+++ b/src/mux.rs
@@ -7,7 +7,8 @@ use whereat::*;
 
 /// Extract ICC profile from WebP data.
 ///
-/// Returns `None` if no ICC profile is present.
+/// Returns `None` if no ICC profile is present. Subject to the internal
+/// 256 MiB hard cap; for a tighter cap, use [`get_icc_profile_with_limits`].
 ///
 /// # Example
 ///
@@ -19,21 +20,41 @@ use whereat::*;
 /// # Ok::<(), webpx::At<webpx::Error>>(())
 /// ```
 pub fn get_icc_profile(webp_data: &[u8]) -> Result<Option<Vec<u8>>> {
-    get_chunk(webp_data, b"ICCP")
+    get_chunk(webp_data, b"ICCP", &crate::Limits::none())
 }
 
 /// Extract EXIF metadata from WebP data.
 ///
-/// Returns `None` if no EXIF data is present.
+/// Returns `None` if no EXIF data is present. Subject to the internal
+/// 256 MiB hard cap; for a tighter cap, use [`get_exif_with_limits`].
 pub fn get_exif(webp_data: &[u8]) -> Result<Option<Vec<u8>>> {
-    get_chunk(webp_data, b"EXIF")
+    get_chunk(webp_data, b"EXIF", &crate::Limits::none())
 }
 
 /// Extract XMP metadata from WebP data.
 ///
-/// Returns `None` if no XMP data is present.
+/// Returns `None` if no XMP data is present. Subject to the internal
+/// 256 MiB hard cap; for a tighter cap, use [`get_xmp_with_limits`].
 pub fn get_xmp(webp_data: &[u8]) -> Result<Option<Vec<u8>>> {
-    get_chunk(webp_data, b"XMP ")
+    get_chunk(webp_data, b"XMP ", &crate::Limits::none())
+}
+
+/// Extract ICC profile, rejecting chunks larger than `limits.max_metadata_bytes`.
+pub fn get_icc_profile_with_limits(
+    webp_data: &[u8],
+    limits: &crate::Limits,
+) -> Result<Option<Vec<u8>>> {
+    get_chunk(webp_data, b"ICCP", limits)
+}
+
+/// Extract EXIF metadata, rejecting chunks larger than `limits.max_metadata_bytes`.
+pub fn get_exif_with_limits(webp_data: &[u8], limits: &crate::Limits) -> Result<Option<Vec<u8>>> {
+    get_chunk(webp_data, b"EXIF", limits)
+}
+
+/// Extract XMP metadata, rejecting chunks larger than `limits.max_metadata_bytes`.
+pub fn get_xmp_with_limits(webp_data: &[u8], limits: &crate::Limits) -> Result<Option<Vec<u8>>> {
+    get_chunk(webp_data, b"XMP ", limits)
 }
 
 /// Helper to create a demuxer from WebP data.
@@ -77,8 +98,13 @@ unsafe fn create_mux_from_data(webp_data: &[u8], copy_data: bool) -> *mut libweb
 /// real-world ICC profile / EXIF / XMP block while bounding the worst case.
 pub(crate) const MAX_METADATA_CHUNK_BYTES: usize = 256 * 1024 * 1024;
 
-/// Get a metadata chunk from WebP data.
-fn get_chunk(webp_data: &[u8], fourcc: &[u8; 4]) -> Result<Option<Vec<u8>>> {
+/// Get a metadata chunk from WebP data, applying both the internal 256 MiB
+/// hard cap and any caller-supplied [`crate::Limits::max_metadata_bytes`].
+fn get_chunk(
+    webp_data: &[u8],
+    fourcc: &[u8; 4],
+    limits: &crate::Limits,
+) -> Result<Option<Vec<u8>>> {
     let demux = unsafe { create_demux(webp_data) };
 
     if demux.is_null() {
@@ -98,6 +124,8 @@ fn get_chunk(webp_data: &[u8], fourcc: &[u8; 4]) -> Result<Option<Vec<u8>>> {
     let result = if found != 0 {
         let chunk_iter = unsafe { chunk_iter.assume_init() };
         if !chunk_iter.chunk.bytes.is_null() && chunk_iter.chunk.size > 0 {
+            // Internal hard cap: protects against `Limits::default()` callers
+            // who didn't set max_metadata_bytes themselves.
             if chunk_iter.chunk.size > MAX_METADATA_CHUNK_BYTES {
                 unsafe {
                     let mut iter = chunk_iter;
@@ -105,10 +133,24 @@ fn get_chunk(webp_data: &[u8], fourcc: &[u8; 4]) -> Result<Option<Vec<u8>>> {
                     libwebp_sys::WebPDemuxDelete(demux);
                 }
                 return Err(at!(Error::InvalidInput(alloc::format!(
-                    "metadata chunk exceeds limit: {} bytes (max {})",
+                    "metadata chunk exceeds internal hard cap: {} bytes (max {})",
                     chunk_iter.chunk.size,
                     MAX_METADATA_CHUNK_BYTES
                 ))));
+            }
+            // Caller-side `Limits::max_metadata_bytes`. Saturate the cast
+            // because chunk.size is usize but max_metadata_bytes is u32; on
+            // 64-bit a > 4 GiB chunk would already be caught by the hard
+            // cap above, so this saturation never widens the threshold.
+            if let Err(e) = limits
+                .check_metadata_bytes(u32::try_from(chunk_iter.chunk.size).unwrap_or(u32::MAX))
+            {
+                unsafe {
+                    let mut iter = chunk_iter;
+                    libwebp_sys::WebPDemuxReleaseChunkIterator(&mut iter);
+                    libwebp_sys::WebPDemuxDelete(demux);
+                }
+                return Err(at!(Error::LimitExceeded(e)));
             }
             let chunk_data = unsafe {
                 core::slice::from_raw_parts(chunk_iter.chunk.bytes, chunk_iter.chunk.size)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1582,6 +1582,66 @@ mod decoder_tests {
     }
 
     #[test]
+    fn test_decoder_max_pixels_rejects_over_budget() {
+        use webpx::{DecoderConfig, Limits};
+
+        // Encode a 100×100 image, then try to decode it with a 50×50 budget.
+        let width = 100;
+        let height = 100;
+        let data = generate_rgba(width, height, 100, 150, 200, 255);
+        let webp = encode_rgba(&data, width, height, 85.0, Unstoppable).expect("encode");
+
+        let cfg = DecoderConfig::new().limits(Limits::none().with_max_pixels(50 * 50));
+        let r = Decoder::new(&webp)
+            .expect("decoder")
+            .config(cfg)
+            .decode_rgba();
+        assert!(
+            r.is_err(),
+            "decode should be rejected when image exceeds max_pixels"
+        );
+
+        // The same image fits a 100×100 budget exactly.
+        let cfg = DecoderConfig::new().limits(Limits::none().with_max_pixels(100 * 100));
+        let r = Decoder::new(&webp)
+            .expect("decoder")
+            .config(cfg)
+            .decode_rgba();
+        assert!(r.is_ok(), "decode should succeed at exact budget");
+
+        // Limits::none() disables the cap (default behavior).
+        let cfg = DecoderConfig::new().limits(Limits::none());
+        let r = Decoder::new(&webp)
+            .expect("decoder")
+            .config(cfg)
+            .decode_rgba();
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn test_decoder_max_pixels_rejects_post_scale() {
+        use webpx::{DecoderConfig, Limits};
+
+        // 100×100 source, scale to 200×200, with a 100×100 budget.
+        // The pre-scale image fits, but the post-scale output doesn't.
+        let width = 100;
+        let height = 100;
+        let data = generate_rgba(width, height, 100, 150, 200, 255);
+        let webp = encode_rgba(&data, width, height, 85.0, Unstoppable).expect("encode");
+
+        let cfg = DecoderConfig::new().limits(Limits::none().with_max_pixels(100 * 100));
+        let r = Decoder::new(&webp)
+            .expect("decoder")
+            .config(cfg)
+            .scale(200, 200)
+            .decode_rgba();
+        assert!(
+            r.is_err(),
+            "scaled output that exceeds budget should be rejected"
+        );
+    }
+
+    #[test]
     fn test_decoder_rgb_with_scaling() {
         let width = 100;
         let height = 100;
@@ -2475,6 +2535,70 @@ mod animation_tests {
                 mode
             );
         }
+    }
+
+    #[test]
+    fn test_animation_decoder_rejects_total_pixels() {
+        // The case `max_pixels` alone misses: a tiny canvas with many
+        // frames whose product exceeds the cumulative cap.
+        use webpx::{AnimationDecoder, AnimationEncoder, ColorMode, Limits};
+
+        let width = 32;
+        let height = 32;
+        let frame_a = generate_rgba(width, height, 100, 150, 200, 255);
+        let frame_b = generate_rgba(width, height, 200, 100, 50, 255);
+
+        // Build a 4-frame animation: 32×32 × 4 = 4096 cumulative pixels.
+        let mut encoder = AnimationEncoder::new(width, height).expect("encoder");
+        encoder.add_frame_rgba(&frame_a, 0).expect("add");
+        encoder.add_frame_rgba(&frame_b, 100).expect("add");
+        encoder.add_frame_rgba(&frame_a, 200).expect("add");
+        encoder.add_frame_rgba(&frame_b, 300).expect("add");
+        let webp = encoder.finish(400).expect("finish");
+
+        // max_pixels passes (each frame is 1024 ≤ 2000) but max_total_pixels
+        // (2000 < 4096) fails.
+        let limits = Limits::none()
+            .with_max_pixels(2000)
+            .with_max_total_pixels(2000);
+        let r = AnimationDecoder::with_options_limits(&webp, ColorMode::Rgba, false, &limits);
+        assert!(
+            r.is_err(),
+            "max_total_pixels should reject cumulative pixel count"
+        );
+
+        // Same but with a generous total cap → succeeds.
+        let limits = Limits::none()
+            .with_max_pixels(2000)
+            .with_max_total_pixels(10_000);
+        let r = AnimationDecoder::with_options_limits(&webp, ColorMode::Rgba, false, &limits);
+        assert!(r.is_ok());
+    }
+
+    #[test]
+    fn test_animation_decoder_rejects_max_frames() {
+        use webpx::{AnimationDecoder, AnimationEncoder, ColorMode, Limits};
+
+        let width = 16;
+        let height = 16;
+        // Distinct frames so libwebp doesn't dedupe.
+        let frame_a = generate_rgba(width, height, 100, 150, 200, 255);
+        let frame_b = generate_rgba(width, height, 50, 200, 100, 255);
+        let frame_c = generate_rgba(width, height, 200, 50, 150, 255);
+
+        let mut encoder = AnimationEncoder::new(width, height).expect("encoder");
+        encoder.add_frame_rgba(&frame_a, 0).expect("add");
+        encoder.add_frame_rgba(&frame_b, 100).expect("add");
+        encoder.add_frame_rgba(&frame_c, 200).expect("add");
+        let webp = encoder.finish(300).expect("finish");
+
+        let limits = Limits::none().with_max_frames(2);
+        let r = AnimationDecoder::with_options_limits(&webp, ColorMode::Rgba, false, &limits);
+        assert!(r.is_err(), "3-frame animation should fail max_frames=2");
+
+        let limits = Limits::none().with_max_frames(10);
+        let r = AnimationDecoder::with_options_limits(&webp, ColorMode::Rgba, false, &limits);
+        assert!(r.is_ok());
     }
 
     #[test]


### PR DESCRIPTION
Closes #4.

## Summary

Introduces `webpx::Limits` — a structured resource policy modeled on `zencodec::ResourceLimits`, replacing the flat `DecoderConfig::max_pixels` shape that this PR originally drafted. Same observable behavior plus more headroom: animation total-pixel and metadata-chunk caps are now part of the same vocabulary.

```rust
use webpx::{Decoder, DecoderConfig, AnimationDecoder, Limits, ColorMode};

let limits = Limits::none()
    .with_max_pixels(64 * 1024 * 1024)              // 64 MP per frame
    .with_max_total_pixels(256 * 1024 * 1024)       // 256 MP across an animation
    .with_max_frames(1024)
    .with_max_metadata_bytes(4 * 1024 * 1024);      // 4 MB ICCP/EXIF/XMP

// Static decode
let img = Decoder::new(data)?.config(DecoderConfig::new().limits(limits)).decode_rgba()?;

// Animation decode (the case max_pixels alone misses)
let anim = AnimationDecoder::with_options_limits(data, ColorMode::Rgba, false, &limits)?;

// Metadata extraction
let icc = webpx::get_icc_profile_with_limits(data, &limits)?;
```

## Changes

### `Limits` struct

- `#[non_exhaustive]`, all fields `pub` so callers can build via either struct literal or `with_*` chained methods.
- Fields match `zencodec::ResourceLimits` vocabulary (so a single shared `Limits` policy can be lifted between imazen codecs):
  - `max_pixels` — per-frame
  - **`max_total_pixels` — `W × H × frame_count`** (the case the user explicitly flagged: a 1000×1000 × 200-frame animation has 200 MP cumulative even though each frame passes a 1 MP per-frame cap)
  - `max_width`, `max_height`
  - `max_input_bytes`, `max_output_bytes`
  - `max_frames`, `max_animation_ms`
  - `max_metadata_bytes` (webpx-specific; layered on top of the existing 256 MiB internal hard cap)
- Threading is intentionally *not* in `Limits` — webpx already has `DecoderConfig::use_threads`; bundling threading into `Limits` (as zencodec does) would create two ways to set it.

### Wiring

- `DecoderConfig::limits(Limits)` + `::get_limits()` — checked in `decode_advanced` via `WebPGetFeatures` *before* `WebPDecode` allocates. Post-scale dimensions also checked.
- `AnimationDecoder::with_options_limits(data, mode, threads, &Limits)` — checked against the canvas + declared `frame_count` from `WebPAnimDecoderGetInfo`, before the first frame is decoded.
- `mux::get_icc_profile_with_limits` / `get_exif_with_limits` / `get_xmp_with_limits` — apply `max_metadata_bytes` against the demuxer-reported chunk size before the `to_vec()` copy. Existing 256 MiB hard cap remains as a floor for callers using `Limits::none()`.

### `Error::LimitExceeded`

- Added as a new variant. `Error` is `#[non_exhaustive]`, so this is non-breaking for `match` arms with `_ =>`.
- `LimitExceeded` enum carries `actual` + `max` per variant for useful messages.
- Implements `core::error::Error` standalone too, for callers who want to `?`-propagate it without wrapping in `webpx::Error`.

### `#[non_exhaustive]` sweep on configs

- `EncoderConfig` and `DecoderConfig` gain `#[non_exhaustive]`. Both have `pub(crate)` fields so external struct-literal construction was already disallowed; the marker documents future growth (`limits`, future knobs).

## Test plan

- [x] `cargo test --all-features` — 33 unit + 1 limits unit + 185 integration (3 new) + 4 soundness + 34 doctests
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] New tests:
  - `test_decoder_max_pixels_rejects_over_budget` — decoder-side, exact budget is OK, over-budget is `Err`, `Limits::none()` is OK
  - `test_decoder_max_pixels_rejects_post_scale` — 100×100 source, scale to 200×200 against a 100×100 budget → rejected
  - `test_animation_decoder_rejects_total_pixels` — 32×32 × 4-frame animation against `max_total_pixels = 2000`: each frame is 1024 (passes per-frame `max_pixels`), cumulative 4096 fails. Confirms `max_total_pixels` catches what per-frame `max_pixels` misses.
  - `test_animation_decoder_rejects_max_frames` — 3-frame animation against `max_frames = 2` → rejected.

## Notes for review

- Field naming intentionally matches `zencodec::ResourceLimits` so a downstream user with both crates can share one policy struct via `From`/`Into` glue (not added here; happy to add if you want it for 0.2.0).
- The `_with_limits` mux variants are additive — existing `get_icc_profile(data)` etc. keep working with the 256 MiB hard cap. Doubles the mux surface, which is the cost of leaving the simple form intact.
- `AnimationDecoder` gains `with_options_limits`; the existing `with_options(data, mode, threads)` delegates to it with `Limits::none()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)