### PR TITLE
Fix streaming buffer out-of-bounds access

### DIFF
--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -281,7 +281,20 @@ impl<'a> StreamingDecoder<'a> {
             return None;
         }
 
-        let size = (stride as usize).saturating_mul(last_y as usize);
+        let bpp = self.color_mode.bytes_per_pixel().unwrap_or(4);
+        let row_bytes = (width as usize).checked_mul(bpp)?;
+        let stride = stride as usize;
+        if stride < row_bytes {
+            return None;
+        }
+        let decoded_rows = last_y as usize;
+        let size = decoded_rows
+            .checked_sub(1)?
+            .checked_mul(stride)?
+            .checked_add(row_bytes)?;
+        if size > isize::MAX as usize {
+            return None;
+        }
 
         let data = unsafe { core::slice::from_raw_parts(ptr, size) };
 

--- a/tests/soundness.rs
+++ b/tests/soundness.rs
@@ -250,3 +250,39 @@ fn streaming_decoder_with_buffer_safe_usage() {
     assert_eq!((decoded_width, decoded_height), (width, height));
     assert_eq!(decoded, rgba);
 }
+
+#[cfg(feature = "streaming")]
+#[test]
+fn streaming_get_partial_respects_external_buffer_minimum_extent() {
+    let width = 1;
+    let height = 2;
+    let rgba = rgba_fixture(width, height);
+    let webp = encode_lossless_rgba(&rgba, width, height);
+
+    // libwebp accepts caller-owned output buffers sized to
+    // `(height - 1) * stride + row_bytes`; the final row does not need
+    // trailing stride padding. The old `get_partial` wrapper exposed
+    // `stride * decoded_rows` bytes instead, so this 1x2 RGBA image with
+    // stride 8 returned a 16-byte slice over a 12-byte buffer. Reading the
+    // last byte of that slice trips ASan as a heap-buffer-overflow.
+    let stride = 8;
+    let row_bytes = width as usize * 4;
+    let expected_partial_len = stride * (height as usize - 1) + row_bytes;
+    let mut output = vec![0xaa; expected_partial_len];
+    let mut decoder = StreamingDecoder::with_buffer(&mut output, stride, ColorMode::Rgba)
+        .expect("streaming decoder with tightly-sized external buffer");
+
+    decoder.append(&webp).expect("streaming decode append");
+    let (partial, partial_width, partial_rows) = decoder
+        .get_partial()
+        .expect("complete decode should be visible");
+
+    assert_eq!((partial_width, partial_rows), (width, height));
+    assert_eq!(partial.len(), expected_partial_len);
+    assert_eq!(partial[partial.len() - 1], rgba[rgba.len() - 1]);
+
+    let (decoded, decoded_width, decoded_height) =
+        decoder.finish().expect("finish on caller-owned buffer");
+    assert_eq!((decoded_width, decoded_height), (width, height));
+    assert_eq!(decoded, rgba);
+}


### PR DESCRIPTION
`StreamingDecoder::get_partial` was exposing `stride * decoded_rows` bytes for caller-owned buffers. libwebp only requires the last decoded row to contain `row_bytes`, not full trailing stride padding, so safe Rust could receive a slice extending past the external buffer. Fixed the slice length calculation in [src/streaming.rs](/home/shnatsel/Code/webpx/src/streaming.rs:284).

Added a focused soundness regression in [tests/soundness.rs](/home/shnatsel/Code/webpx/tests/soundness.rs:256). The comment next to the test describes the UB: before the fix, the test returned a 16-byte slice over a 12-byte buffer, and reading its last byte trips ASan as a heap-buffer-overflow.

Verification:

`ASAN_OPTIONS=detect_leaks=0 RUSTFLAGS='-Zsanitizer=address' cargo +nightly test -Zbuild-std --release --target x86_64-unknown-linux-gnu --all-features --tests` fails after the unit test was added, passes again with the fix.

The issue was discovered by GPT-5.5