### PR TITLE
Use zeroed RAII wrapper everywhere to avoid reading uninit memory

### DIFF
--- a/src/animation.rs
+++ b/src/animation.rs
@@ -528,6 +528,11 @@ impl AnimationEncoder {
 
         let webp_config = self.config.to_libwebp()?;
 
+        // Use webpx's zeroed RAII wrapper, not
+        // `libwebp_sys::WebPPicture::new()`: the generated helper starts from
+        // uninitialized memory, but bindgen exposes libwebp's reserved fields
+        // as normal Rust fields. If libwebp leaves any of those fields
+        // untouched, `assume_init` would construct an invalid Rust value.
         let mut picture = Picture::new()?;
         picture.inner_mut().width = self.width as i32;
         picture.inner_mut().height = self.height as i32;

--- a/src/animation.rs
+++ b/src/animation.rs
@@ -3,6 +3,8 @@
 #[cfg(feature = "encode")]
 use crate::config::{EncoderConfig, Preset};
 use crate::error::{Error, Result};
+#[cfg(feature = "encode")]
+use crate::ffi::picture::Picture;
 use crate::types::ColorMode;
 #[cfg(feature = "encode")]
 use crate::types::{EncodePixel, PixelLayout};
@@ -526,41 +528,41 @@ impl AnimationEncoder {
 
         let webp_config = self.config.to_libwebp()?;
 
-        let mut picture = libwebp_sys::WebPPicture::new()
-            .map_err(|_| at!(Error::InvalidConfig("failed to init picture".into())))?;
-
-        picture.width = self.width as i32;
-        picture.height = self.height as i32;
-        picture.use_argb = 1;
+        let mut picture = Picture::new()?;
+        picture.inner_mut().width = self.width as i32;
+        picture.inner_mut().height = self.height as i32;
+        picture.inner_mut().use_argb = 1;
 
         let stride = (self.width as usize * bpp) as i32;
         let import_ok = unsafe {
             match layout {
                 PixelLayout::Rgba => {
-                    libwebp_sys::WebPPictureImportRGBA(&mut picture, data.as_ptr(), stride)
+                    libwebp_sys::WebPPictureImportRGBA(picture.as_mut_ptr(), data.as_ptr(), stride)
                 }
                 PixelLayout::Rgb => {
-                    libwebp_sys::WebPPictureImportRGB(&mut picture, data.as_ptr(), stride)
+                    libwebp_sys::WebPPictureImportRGB(picture.as_mut_ptr(), data.as_ptr(), stride)
                 }
                 PixelLayout::Bgra => {
-                    libwebp_sys::WebPPictureImportBGRA(&mut picture, data.as_ptr(), stride)
+                    libwebp_sys::WebPPictureImportBGRA(picture.as_mut_ptr(), data.as_ptr(), stride)
                 }
                 PixelLayout::Bgr => {
-                    libwebp_sys::WebPPictureImportBGR(&mut picture, data.as_ptr(), stride)
+                    libwebp_sys::WebPPictureImportBGR(picture.as_mut_ptr(), data.as_ptr(), stride)
                 }
             }
         };
 
         if import_ok == 0 {
-            unsafe { libwebp_sys::WebPPictureFree(&mut picture) };
             return Err(at!(Error::OutOfMemory));
         }
 
         let ok = unsafe {
-            libwebp_sys::WebPAnimEncoderAdd(self.encoder, &mut picture, timestamp_ms, &webp_config)
+            libwebp_sys::WebPAnimEncoderAdd(
+                self.encoder,
+                picture.as_mut_ptr(),
+                timestamp_ms,
+                &webp_config,
+            )
         };
-
-        unsafe { libwebp_sys::WebPPictureFree(&mut picture) };
 
         if ok == 0 {
             let error_msg = unsafe {

--- a/src/decode.rs
+++ b/src/decode.rs
@@ -880,8 +880,19 @@ impl<'a> Decoder<'a> {
             return Err(at!(Error::LimitExceeded(e)));
         }
 
-        let mut dec_config = libwebp_sys::WebPDecoderConfig::new()
-            .map_err(|_| at!(Error::InvalidConfig("failed to init decoder config".into())))?;
+        // `libwebp_sys::WebPDecoderConfig::new()` starts from
+        // `MaybeUninit::uninit()`. The generated binding exposes libwebp's
+        // reserved `pad` arrays as ordinary Rust fields, so assume_init would
+        // be UB if libwebp left any of them untouched. Start from zeroed memory
+        // and then let libwebp populate the documented fields.
+        let mut dec_config = core::mem::MaybeUninit::<libwebp_sys::WebPDecoderConfig>::zeroed();
+        let ok = unsafe { libwebp_sys::WebPInitDecoderConfig(dec_config.as_mut_ptr()) };
+        if !ok {
+            return Err(at!(Error::InvalidConfig(
+                "failed to init decoder config".into(),
+            )));
+        }
+        let mut dec_config = unsafe { dec_config.assume_init() };
 
         // Get features
         let status = unsafe {

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -449,6 +449,11 @@ impl StreamingEncoder {
 
         let webp_config = self.config.to_libwebp()?;
 
+        // Use webpx's zeroed RAII wrapper, not
+        // `libwebp_sys::WebPPicture::new()`: the generated helper starts from
+        // uninitialized memory, but bindgen exposes libwebp's reserved fields
+        // as normal Rust fields. If libwebp leaves any of those fields
+        // untouched, `assume_init` would construct an invalid Rust value.
         let mut picture = Picture::new()?;
         picture.inner_mut().width = self.width as i32;
         picture.inner_mut().height = self.height as i32;
@@ -479,6 +484,9 @@ impl StreamingEncoder {
         ) -> i32 {
             let ctx = unsafe { &mut *((*picture).custom_ptr as *mut CallbackContext<F>) };
 
+            // libwebp normally provides a non-null pointer for non-empty
+            // chunks. Guard the empty/null case anyway so we never build a
+            // Rust slice from a null raw pointer.
             let slice = if data.is_null() || data_size == 0 {
                 &[]
             } else {
@@ -530,6 +538,9 @@ impl StreamingEncoder {
 
         let webp_config = self.config.to_libwebp()?;
 
+        // Same initializedness invariant as the RGBA callback path above:
+        // avoid the generated `WebPPicture::new()` helper and keep all
+        // libwebp-reserved fields zeroed before C initialization.
         let mut picture = Picture::new()?;
         picture.inner_mut().width = self.width as i32;
         picture.inner_mut().height = self.height as i32;
@@ -547,8 +558,11 @@ impl StreamingEncoder {
             return Err(at!(Error::OutOfMemory));
         }
 
-        // Use memory writer and send all at once for simplicity
-        // (libwebp doesn't truly stream the output)
+        // Use the zeroed RAII writer wrapper for the same reason as
+        // `Picture`: the generated C initializer may leave reserved fields
+        // alone, and Drop must always clear libwebp's allocation on errors.
+        // We send the encoded bytes all at once because libwebp doesn't truly
+        // stream encoder output.
         let mut writer = MemWriter::new();
 
         picture.inner_mut().writer = Some(libwebp_sys::WebPMemoryWrite);

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1,6 +1,10 @@
 //! Streaming/incremental WebP decode and encode.
 
 use crate::error::{DecodingError, Error, Result};
+#[cfg(feature = "encode")]
+use crate::ffi::mem_writer::MemWriter;
+#[cfg(feature = "encode")]
+use crate::ffi::picture::Picture;
 use crate::types::ColorMode;
 use alloc::vec::Vec;
 use core::marker::PhantomData;
@@ -445,19 +449,20 @@ impl StreamingEncoder {
 
         let webp_config = self.config.to_libwebp()?;
 
-        let mut picture = libwebp_sys::WebPPicture::new()
-            .map_err(|_| at!(Error::InvalidConfig("failed to init picture".into())))?;
-
-        picture.width = self.width as i32;
-        picture.height = self.height as i32;
-        picture.use_argb = 1;
+        let mut picture = Picture::new()?;
+        picture.inner_mut().width = self.width as i32;
+        picture.inner_mut().height = self.height as i32;
+        picture.inner_mut().use_argb = 1;
 
         let import_ok = unsafe {
-            libwebp_sys::WebPPictureImportRGBA(&mut picture, data.as_ptr(), (self.width * 4) as i32)
+            libwebp_sys::WebPPictureImportRGBA(
+                picture.as_mut_ptr(),
+                data.as_ptr(),
+                (self.width * 4) as i32,
+            )
         };
 
         if import_ok == 0 {
-            unsafe { libwebp_sys::WebPPictureFree(&mut picture) };
             return Err(at!(Error::OutOfMemory));
         }
 
@@ -474,7 +479,11 @@ impl StreamingEncoder {
         ) -> i32 {
             let ctx = unsafe { &mut *((*picture).custom_ptr as *mut CallbackContext<F>) };
 
-            let slice = unsafe { core::slice::from_raw_parts(data, data_size) };
+            let slice = if data.is_null() || data_size == 0 {
+                &[]
+            } else {
+                unsafe { core::slice::from_raw_parts(data, data_size) }
+            };
 
             match (ctx.callback)(slice) {
                 Ok(()) => 1,
@@ -490,21 +499,18 @@ impl StreamingEncoder {
             error: None,
         };
 
-        picture.writer = Some(write_callback::<F>);
-        picture.custom_ptr = &mut ctx as *mut _ as *mut _;
+        picture.inner_mut().writer = Some(write_callback::<F>);
+        picture.inner_mut().custom_ptr = &mut ctx as *mut _ as *mut _;
 
-        let ok = unsafe { libwebp_sys::WebPEncode(&webp_config, &mut picture) };
-
-        unsafe { libwebp_sys::WebPPictureFree(&mut picture) };
+        let ok = unsafe { libwebp_sys::WebPEncode(&webp_config, picture.as_mut_ptr()) };
 
         if let Some(e) = ctx.error {
             return Err(e);
         }
 
         if ok == 0 {
-            return Err(at!(Error::EncodeFailed(crate::error::EncodingError::from(
-                picture.error_code as i32,
-            ))));
+            let error = crate::error::EncodingError::from(picture.inner_mut().error_code as i32);
+            return Err(at!(Error::EncodeFailed(error)));
         }
 
         Ok(())
@@ -524,53 +530,39 @@ impl StreamingEncoder {
 
         let webp_config = self.config.to_libwebp()?;
 
-        let mut picture = libwebp_sys::WebPPicture::new()
-            .map_err(|_| at!(Error::InvalidConfig("failed to init picture".into())))?;
-
-        picture.width = self.width as i32;
-        picture.height = self.height as i32;
-        picture.use_argb = 1;
+        let mut picture = Picture::new()?;
+        picture.inner_mut().width = self.width as i32;
+        picture.inner_mut().height = self.height as i32;
+        picture.inner_mut().use_argb = 1;
 
         let import_ok = unsafe {
-            libwebp_sys::WebPPictureImportRGB(&mut picture, data.as_ptr(), (self.width * 3) as i32)
+            libwebp_sys::WebPPictureImportRGB(
+                picture.as_mut_ptr(),
+                data.as_ptr(),
+                (self.width * 3) as i32,
+            )
         };
 
         if import_ok == 0 {
-            unsafe { libwebp_sys::WebPPictureFree(&mut picture) };
             return Err(at!(Error::OutOfMemory));
         }
 
         // Use memory writer and send all at once for simplicity
         // (libwebp doesn't truly stream the output)
-        let mut writer = core::mem::MaybeUninit::<libwebp_sys::WebPMemoryWriter>::zeroed();
-        unsafe { libwebp_sys::WebPMemoryWriterInit(writer.as_mut_ptr()) };
-        let mut writer = unsafe { writer.assume_init() };
+        let mut writer = MemWriter::new();
 
-        picture.writer = Some(libwebp_sys::WebPMemoryWrite);
-        picture.custom_ptr = &mut writer as *mut _ as *mut _;
+        picture.inner_mut().writer = Some(libwebp_sys::WebPMemoryWrite);
+        picture.inner_mut().custom_ptr = writer.as_mut_ptr() as *mut _;
 
-        let ok = unsafe { libwebp_sys::WebPEncode(&webp_config, &mut picture) };
+        let ok = unsafe { libwebp_sys::WebPEncode(&webp_config, picture.as_mut_ptr()) };
 
         if ok == 0 {
-            let error = crate::error::EncodingError::from(picture.error_code as i32);
-            unsafe {
-                libwebp_sys::WebPPictureFree(&mut picture);
-                libwebp_sys::WebPMemoryWriterClear(&mut writer);
-            }
+            let error = crate::error::EncodingError::from(picture.inner_mut().error_code as i32);
             return Err(at!(Error::EncodeFailed(error)));
         }
 
-        let result = unsafe {
-            let slice = core::slice::from_raw_parts(writer.mem, writer.size);
-            callback(slice)
-        };
-
-        unsafe {
-            libwebp_sys::WebPPictureFree(&mut picture);
-            libwebp_sys::WebPMemoryWriterClear(&mut writer);
-        }
-
-        result
+        let encoded = writer.to_vec();
+        callback(&encoded)
     }
 }
 


### PR DESCRIPTION
The crate already had the correct approach implemented, but it wasn't applied unversally.

I couldn't trigger UB on regression tests because this would either require miri (which can't run with C FFI) or Memory Sanitizer that instruments both C and Rust code and that's a massive hassle to set up. So I'm not including any additional tests for this change.