### PR TITLE
Fix some encode paths silently dropping metadata

### DIFF
--- a/src/encode.rs
+++ b/src/encode.rs
@@ -97,6 +97,43 @@ fn resume_progress_panic<S: Stop>(ctx: &StopContext<S>) {
 #[cfg(not(feature = "std"))]
 fn resume_progress_panic<S: Stop>(_ctx: &StopContext<S>) {}
 
+#[cfg(feature = "icc")]
+fn has_config_metadata(config: &EncoderConfig) -> bool {
+    config.icc_profile.is_some() || config.exif_data.is_some() || config.xmp_data.is_some()
+}
+
+#[cfg(feature = "icc")]
+fn has_encoder_metadata(config: &EncoderConfig, icc_profile: Option<&[u8]>) -> bool {
+    icc_profile.is_some() || has_config_metadata(config)
+}
+
+#[cfg(feature = "icc")]
+fn embed_config_metadata(mut webp_data: Vec<u8>, config: &EncoderConfig) -> Result<Vec<u8>> {
+    if let Some(ref icc) = config.icc_profile {
+        webp_data = crate::mux::embed_icc(&webp_data, icc)?;
+    }
+    if let Some(ref exif) = config.exif_data {
+        webp_data = crate::mux::embed_exif(&webp_data, exif)?;
+    }
+    if let Some(ref xmp) = config.xmp_data {
+        webp_data = crate::mux::embed_xmp(&webp_data, xmp)?;
+    }
+    Ok(webp_data)
+}
+
+#[cfg(feature = "icc")]
+fn embed_encoder_metadata(
+    webp_data: Vec<u8>,
+    config: &EncoderConfig,
+    icc_profile: Option<&[u8]>,
+) -> Result<Vec<u8>> {
+    let mut webp_data = embed_config_metadata(webp_data, config)?;
+    if let Some(icc) = icc_profile {
+        webp_data = crate::mux::embed_icc(&webp_data, icc)?;
+    }
+    Ok(webp_data)
+}
+
 /// Internal: Encode with full config and return stats (called by EncoderConfig).
 pub(crate) fn encode_with_config_stats(
     data: &[u8],
@@ -164,15 +201,7 @@ pub(crate) fn encode_with_config_stats(
     // Embed metadata if present
     #[cfg(feature = "icc")]
     if let Ok((mut webp_data, stats)) = result {
-        if let Some(ref icc) = config.icc_profile {
-            webp_data = crate::mux::embed_icc(&webp_data, icc)?;
-        }
-        if let Some(ref exif) = config.exif_data {
-            webp_data = crate::mux::embed_exif(&webp_data, exif)?;
-        }
-        if let Some(ref xmp) = config.xmp_data {
-            webp_data = crate::mux::embed_xmp(&webp_data, xmp)?;
-        }
+        webp_data = embed_config_metadata(webp_data, config)?;
         return Ok((webp_data, stats));
     }
 
@@ -263,15 +292,7 @@ pub(crate) fn encode_with_config_stoppable<S: Stop>(
     // Embed metadata if present
     #[cfg(feature = "icc")]
     if let Ok(mut webp_data) = result {
-        if let Some(ref icc) = config.icc_profile {
-            webp_data = crate::mux::embed_icc(&webp_data, icc)?;
-        }
-        if let Some(ref exif) = config.exif_data {
-            webp_data = crate::mux::embed_exif(&webp_data, exif)?;
-        }
-        if let Some(ref xmp) = config.xmp_data {
-            webp_data = crate::mux::embed_xmp(&webp_data, xmp)?;
-        }
+        webp_data = embed_config_metadata(webp_data, config)?;
         return Ok(webp_data);
     }
 
@@ -987,13 +1008,11 @@ impl<'a> Encoder<'a> {
                 Err(at!(Error::EncodeFailed(EncodingError::from(error_code))))
             }
         } else {
-            let webp_data = writer.to_vec();
-
+            let mut webp_data = writer.to_vec();
             #[cfg(feature = "icc")]
-            if let Some(icc) = self.icc_profile {
-                return crate::mux::embed_icc(&webp_data, icc);
+            {
+                webp_data = embed_encoder_metadata(webp_data, &self.config, self.icc_profile)?;
             }
-
             Ok(webp_data)
         }
     }
@@ -1072,14 +1091,13 @@ impl<'a> Encoder<'a> {
             return Err(at!(Error::EncodeFailed(EncodingError::from(error_code))));
         }
 
-        // Note: ICC profile embedding is not supported with encode_owned()
-        // because it requires reallocating the buffer. Use encode() instead.
+        // Metadata embedding uses the muxer to assemble a new buffer, so it
+        // cannot preserve encode_owned()'s libwebp-owned zero-copy return.
         #[cfg(feature = "icc")]
-        if self.icc_profile.is_some() {
+        if has_encoder_metadata(&self.config, self.icc_profile) {
             // writer drops here (frees libwebp memory via Clear)
             return Err(at!(Error::InvalidConfig(
-                "ICC profile embedding not supported with encode_owned(), use encode() instead"
-                    .into()
+                "metadata embedding not supported with encode_owned(), use encode() instead".into()
             )));
         }
 
@@ -1110,6 +1128,13 @@ impl<'a> Encoder<'a> {
     /// # Ok::<(), webpx::At<webpx::Error>>(())
     /// ```
     pub fn encode_into<S: Stop>(self, stop: S, output: &mut Vec<u8>) -> Result<()> {
+        #[cfg(feature = "icc")]
+        if has_encoder_metadata(&self.config, self.icc_profile) {
+            let data = self.encode(stop)?;
+            output.extend_from_slice(&data);
+            return Ok(());
+        }
+
         let data = self.encode_owned(stop)?;
         output.extend_from_slice(&data);
         Ok(())
@@ -1144,6 +1169,15 @@ impl<'a> Encoder<'a> {
         stop: S,
         mut writer: W,
     ) -> Result<()> {
+        #[cfg(feature = "icc")]
+        if has_encoder_metadata(&self.config, self.icc_profile) {
+            let data = self.encode(stop)?;
+            writer
+                .write_all(&data)
+                .map_err(|e| at!(Error::IoError(e.to_string())))?;
+            return Ok(());
+        }
+
         let data = self.encode_owned(stop)?;
         writer
             .write_all(&data)

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1162,6 +1162,24 @@ mod icc_tests {
         profile
     }
 
+    fn assert_embedded_metadata(webp: &[u8], icc: &[u8], exif: &[u8], xmp: &[u8]) {
+        assert_eq!(
+            get_icc_profile(webp).expect("get ICC failed").as_deref(),
+            Some(icc),
+            "ICC profile should be embedded"
+        );
+        assert_eq!(
+            get_exif(webp).expect("get EXIF failed").as_deref(),
+            Some(exif),
+            "EXIF data should be embedded"
+        );
+        assert_eq!(
+            get_xmp(webp).expect("get XMP failed").as_deref(),
+            Some(xmp),
+            "XMP data should be embedded"
+        );
+    }
+
     #[test]
     fn test_icc_embed_extract() {
         let width = 32;
@@ -1246,6 +1264,83 @@ mod icc_tests {
         let (_, w, h) = decode_rgba(&webp_no_icc).expect("decode failed");
         assert_eq!(w, width);
         assert_eq!(h, height);
+    }
+
+    #[test]
+    fn test_encoder_config_metadata_reaches_encoder_backed_paths() {
+        let width = 8;
+        let height = 8;
+        let icc = create_minimal_icc_profile();
+        let exif = b"Exif\0\0MM\0*config metadata".to_vec();
+        let xmp = b"<?xpacket begin=''?><x:xmpmeta>config metadata</x:xmpmeta>".to_vec();
+        let config = EncoderConfig::new()
+            .quality(85.0)
+            .icc_profile(icc.clone())
+            .exif(exif.clone())
+            .xmp(xmp.clone());
+
+        let bgra: Vec<u8> = (0..(width * height))
+            .flat_map(|_| [30u8, 20, 10, 255])
+            .collect();
+        let webp = config
+            .encode_bgra(&bgra, width, height, Unstoppable)
+            .expect("encode BGRA with config metadata");
+        assert_embedded_metadata(&webp, &icc, &exif, &xmp);
+
+        let bgr: Vec<u8> = (0..(width * height)).flat_map(|_| [30u8, 20, 10]).collect();
+        let webp = config
+            .encode_bgr(&bgr, width, height, Unstoppable)
+            .expect("encode BGR with config metadata");
+        assert_embedded_metadata(&webp, &icc, &exif, &xmp);
+
+        let pixels = vec![rgb::RGBA8::new(10, 20, 30, 255); (width * height) as usize];
+        let img = imgref::Img::new(pixels.as_slice(), width as usize, height as usize);
+        let webp = config
+            .encode_img(img, Unstoppable)
+            .expect("encode imgref image with config metadata");
+        assert_embedded_metadata(&webp, &icc, &exif, &xmp);
+
+        let mut output = Vec::new();
+        Encoder::new_bgra(&bgra, width, height)
+            .config(config.clone())
+            .encode_into(Unstoppable, &mut output)
+            .expect("encode into Vec with config metadata");
+        assert_embedded_metadata(&output, &icc, &exif, &xmp);
+
+        #[cfg(feature = "std")]
+        {
+            let rgba = generate_rgba(width, height, 10, 20, 30, 255);
+            let mut output = Vec::new();
+            Encoder::new_rgba(&rgba, width, height)
+                .config(config.clone())
+                .encode_to_writer(Unstoppable, &mut output)
+                .expect("encode to writer with config metadata");
+            assert_embedded_metadata(&output, &icc, &exif, &xmp);
+        }
+    }
+
+    #[test]
+    fn test_encode_owned_rejects_encoder_config_metadata() {
+        let width = 8;
+        let height = 8;
+        let data = generate_rgba(width, height, 100, 150, 200, 255);
+        let config = EncoderConfig::new().icc_profile(create_minimal_icc_profile());
+
+        let err = match Encoder::new_rgba(&data, width, height)
+            .config(config)
+            .encode_owned(Unstoppable)
+        {
+            Ok(_) => panic!("encode_owned should reject metadata from EncoderConfig"),
+            Err(err) => err,
+        };
+
+        match err.error() {
+            Error::InvalidConfig(message) => assert!(
+                message.contains("metadata embedding"),
+                "unexpected error message: {message}"
+            ),
+            other => panic!("expected InvalidConfig, got {other:?}"),
+        }
     }
 }
 


### PR DESCRIPTION
`EncoderConfig` metadata embedding was inconsistent across encode entry points. The direct RGBA/RGB helpers call `encode_with_config_stoppable`,  which embeds configured ICC/EXIF/XMP data, but BGRA/BGR and `encode_img`   route through `Encoder::config(self.clone()).encode(...)`; that path only  consults `Encoder::icc_profile(...)` and appears to ignore metadata stored   inside the supplied `EncoderConfig`. `Encoder::encode_owned` has the same  silent-ignore shape for metadata carried by `EncoderConfig`.

This PR makes `Encoder::encode_owned` return an error when trying to encode with metadata, since that would require reallocation, and fixes all other encode paths to embed metadata consistently.