### PR TITLE
docs(webpx): add README (codec was published with none)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `docs(readme)`: rewrote the README — decode/encode quick-start, server-safety section (`Limits` + cooperative cancellation), key-types and features tables, factual on-its-own-terms framing, `?style=flat-square` badges, and `readme = "README.md"` in `Cargo.toml`. Fixed stale install versions (now `0.4.0`) and MSRV (`1.89`).
+
 ## [0.4.0] - 2026-06-10
 
 ### Changed — BREAKING

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ version = "0.4.0"
 edition = "2024"
 rust-version = "1.89"
 license = "MIT OR Apache-2.0"
+readme = "README.md"
 description = "Complete WebP encoding/decoding with ICC profiles, streaming, and animation support"
 repository = "https://github.com/imazen/webpx"
 keywords = ["webp", "image", "codec", "icc", "animation"]

--- a/README.md
+++ b/README.md
@@ -1,75 +1,73 @@
-# webpx
+# webpx ![CI](https://img.shields.io/github/actions/workflow/status/imazen/webpx/ci.yml?style=flat-square&label=CI) ![crates.io](https://img.shields.io/crates/v/webpx?style=flat-square) [![lib.rs](https://img.shields.io/crates/v/webpx?style=flat-square&label=lib.rs&color=blue)](https://lib.rs/crates/webpx) ![docs.rs](https://img.shields.io/docsrs/webpx?style=flat-square) ![license](https://img.shields.io/crates/l/webpx?style=flat-square)
 
-[![CI](https://github.com/imazen/webpx/actions/workflows/ci.yml/badge.svg)](https://github.com/imazen/webpx/actions/workflows/ci.yml)
-[![Crates.io](https://img.shields.io/crates/v/webpx.svg)](https://crates.io/crates/webpx)
-[![Docs.rs](https://docs.rs/webpx/badge.svg)](https://docs.rs/webpx)
-[![codecov](https://codecov.io/gh/imazen/webpx/branch/main/graph/badge.svg)](https://codecov.io/gh/imazen/webpx)
-[![License](https://img.shields.io/crates/l/webpx.svg)](https://github.com/imazen/webpx#license)
+Ergonomic Rust bindings to Google's [libwebp](https://chromium.googlesource.com/webm/libwebp), covering lossy and lossless encode/decode, animation, ICC/EXIF/XMP metadata, streaming, and `no_std`.
 
-**Ergonomic FFI bindings to Google's libwebp**, with support for static images, animations, ICC profiles, streaming, and `no_std`.
+`webpx` wraps the upstream libwebp C library (via [`libwebp-sys`](https://crates.io/crates/libwebp-sys)) behind a typed, builder-style API. It adds a resource-`Limits` policy and cooperative cancellation so the codec is safe to run against untrusted uploads, and it ships compatibility shims for drop-in migration from the `webp` and `webp-animation` crates. Reach for `webpx` when your application already links libwebp through another path (existing C/C++ code, a system package), when you need libwebp's hand-tuned DSP code paths, or when you've benchmarked your content and confirmed libwebp wins.
 
-## Use [`zenwebp`](https://github.com/imazen/zenwebp) instead
+> Pure-Rust alternative: [`zenwebp`](https://github.com/imazen/zenwebp) is a `#![forbid(unsafe_code)]` reimplementation with native `wasm32-unknown-unknown` support. Its `zencodec` trait surface mirrors `webpx`'s, so the same caller code works against either crate — see the `zencodec` feature below.
 
-For any new project, reach for **[`zenwebp`](https://github.com/imazen/zenwebp)**. It is equally or more capable than `webpx` on every axis that matters:
-
-- **Full feature parity** with libwebp: lossy and lossless encode and decode, animation, alpha, ICC / EXIF / XMP metadata, streaming, content presets, resource limits.
-- **Native `wasm32-unknown-unknown` support** — pure Rust, no C compiler, no emscripten. `webpx` requires emscripten because libwebp is C.
-- **`#![forbid(unsafe_code)]`** — pure Rust top to bottom. Zero FFI surface, zero `unsafe` blocks.
-
-Performance and compression are essentially a wash:
-
-- libwebp can be **up to 35 % faster on specific photos**, but it can also be **up to 2.5× slower** on others. Net wash unless you're tuned to specific content types.
-- Encoded-size difference is at most **~0.02 %** — noise, not meaningful.
-
-The security argument is concrete, not theoretical:
-
-- **libwebp has a documented history of high-severity vulnerabilities.** CVE-2023-4863 was a heap buffer overflow in `BuildHuffmanTable` actively exploited in the wild against Chrome, Safari, Firefox, and Electron apps via a 0-click attack chain — patched out of band on every major platform. That is the failure mode an FFI wrapper inherits, not a hypothetical.
-- **Every libwebp wrapper that has been audited has shipped soundness bugs**, `webpx` included. Versions 0.1.0–0.1.4 are yanked, and 0.2.0 + 0.2.1 fixed multiple stride-overflow / use-after-free / aliasing issues found across two parallel audit passes. If you adopt a libwebp wrapper, you are taking on that exposure.
-
-`zenwebp`'s `#![forbid(unsafe_code)]` makes that whole class of bug structurally impossible. Use it.
-
-`webpx` is maintained for users whose application already links libwebp through another path (existing C / C++ code, system package) and would prefer to share that codebase, or who specifically need libwebp's MIPS DSP code paths. If that's not you, switch.
-
-## Why use webpx anyway?
-
-- **Ergonomic Rust API** — Builder patterns, strong types, comprehensive error handling, `Limits` policy for untrusted-input decoding
-- **Shares an existing libwebp link** — If your application already links libwebp via another path (C / C++ code, system package), `webpx` reuses that codebase rather than pulling in a second WebP implementation
-- **MIPS DSP** — libwebp ships hand-written MIPS DSP-R2 / DSP-ASE assembly paths. If you target that hardware, `webpx` inherits them; `zenwebp` does not.
-- **Up to 35 % faster on specific photos** — libwebp's hand-tuned VP8 path beats pure-Rust on some content. Note that it can also be up to 2.5× slower on other content; benchmark your actual workload.
-
-## Quick Start
+## Install
 
 ```toml
 [dependencies]
-webpx = "0.2"
+webpx = "0.4.0"
 ```
+
+Opt into the non-default features you need:
+
+```toml
+[dependencies]
+webpx = { version = "0.4.0", features = ["animation", "icc", "streaming"] }
+```
+
+## Quick start
+
+`webpx` works in 8-bit interleaved channel order. Decode produces tightly packed `RGBA` (`R, G, B, A` per pixel, top-to-bottom); the `Encoder::new_rgba` constructor expects the same. `RGB`, `BGRA`, and `BGR` variants are available on both sides.
+
+### Decode (WebP bytes -> RGBA)
 
 ```rust
-use webpx::{Encoder, decode_rgba, Unstoppable};
+use webpx::decode_rgba;
 
-// Encode RGBA pixels to WebP
-let webp = Encoder::new_rgba(&pixels, width, height)
-    .quality(85.0)
-    .encode(Unstoppable)?;
-
-// Decode WebP back to RGBA
-let (pixels, w, h) = decode_rgba(&webp)?;
+// `webp_bytes` is the contents of a .webp file.
+let (pixels, width, height) = decode_rgba(&webp_bytes)?;
+// `pixels.len() == width as usize * height as usize * 4`, in R,G,B,A order.
+# Ok::<(), webpx::At<webpx::Error>>(())
 ```
 
-## Decoding untrusted input
+`decode_rgba` enforces `Limits::default()` on the input — see [Decoding untrusted input](#decoding-untrusted-input). For metadata-stripping, cropping/scaling, BGRA, or zero-copy output, use the [`Decoder`](#decoding-with-cropping--scaling) builder.
 
-`Limits::default()` applies **opinionated production caps** suited to
-typical web / image-server use, and **every decode-side entry point
-enforces them unless you opt out** — the free functions (`decode_rgba`,
-`decode_yuv`, `get_icc_profile`, ...), the `Decoder` builder, the
-`AnimationDecoder`, and the `StreamingDecoder` alike. Defaults: 64 MP
-per frame, 256 MP cumulative, 16383×16383 (libwebp's intrinsic limit),
-64 MiB input, 4096 frames, 5 min animation, 4 MiB metadata, 256 MiB
-output. Override individual fields via the `with_*` builders on top of
-`Limits::default()`, or pass `Limits::none()` through the configurable
-paths (`DecoderConfig::limits`, `with_options_limits`, `_with_limits`,
-`StreamingDecoder::limits`) to opt out entirely (only when you fully
-trust the input).
+### Encode (RGBA -> WebP bytes)
+
+```rust
+use webpx::{Encoder, Unstoppable};
+
+// A 2x2 RGBA image: red, green, blue, white.
+let rgba: Vec<u8> = vec![
+    255, 0, 0, 255,
+    0, 255, 0, 255,
+    0, 0, 255, 255,
+    255, 255, 255, 255,
+];
+
+// Lossy, quality 0.0..=100.0.
+let webp = Encoder::new_rgba(&rgba, 2, 2)
+    .quality(85.0)
+    .encode(Unstoppable)?;
+# Ok::<(), webpx::At<webpx::Error>>(())
+```
+
+`Unstoppable` opts out of cancellation; pass a real `Stop` value to make long encodes interruptible (see [Cooperative cancellation](#cooperative-cancellation)).
+
+## Server safety
+
+A codec that decodes untrusted uploads needs two things: bounded resource use and the ability to abort. `webpx` provides both.
+
+### Decoding untrusted input
+
+`Limits::default()` applies opinionated production caps suited to typical web / image-server use, and **every decode-side entry point enforces them unless you opt out** — the free functions (`decode_rgba`, `decode_yuv`, `get_icc_profile`, ...), the `Decoder` builder, the `AnimationDecoder`, and the `StreamingDecoder` alike. Defaults: 64 MP per frame, 256 MP cumulative, 16383×16383 (libwebp's intrinsic limit), 64 MiB input, 4096 frames, 5 min animation, 4 MiB metadata, 256 MiB output.
+
+Override individual fields with the `with_*` builders on top of `Limits::default()`, or pass `Limits::none()` through the configurable paths (`DecoderConfig::limits`, `AnimationDecoder::with_options_limits`, the `get_*_with_limits` getters, `StreamingDecoder::limits`) to opt out entirely — only when the input source is fully trusted.
 
 ```rust
 use webpx::{Decoder, DecoderConfig, Limits};
@@ -77,224 +75,25 @@ use webpx::{Decoder, DecoderConfig, Limits};
 // Tighter than default: 16 MP per frame for a thumbnail decoder.
 let limits = Limits::default().with_max_pixels(16 * 1024 * 1024);
 
-let img = Decoder::new(webp_data)?
+let (pixels, w, h) = Decoder::new(&webp_data)?
     .config(DecoderConfig::new().limits(limits))
-    .decode_rgba()?;
-```
-
-The same `Limits` value also wires into [`AnimationDecoder::with_options_limits`]
-and [`mux::get_icc_profile_with_limits`] (and the `_with_limits` variants
-for EXIF / XMP). Field naming matches `zencodec::ResourceLimits` so a
-single shared policy carries cleanly between Imazen codecs.
-
-[`Limits`]: https://docs.rs/webpx/latest/webpx/struct.Limits.html
-[`AnimationDecoder::with_options_limits`]: https://docs.rs/webpx/latest/webpx/struct.AnimationDecoder.html#method.with_options_limits
-[`mux::get_icc_profile_with_limits`]: https://docs.rs/webpx/latest/webpx/fn.get_icc_profile_with_limits.html
-
-## Features at a Glance
-
-| Feature | Description |
-|---------|-------------|
-| **Lossy Encoding** | VP8-based compression with quality 0-100 |
-| **Lossless Encoding** | Exact pixel preservation |
-| **Alpha Channel** | Full transparency support with separate quality control |
-| **Animation** | Multi-frame WebP with timing control |
-| **ICC Profiles** | Embed/extract color profiles |
-| **EXIF/XMP** | Preserve camera metadata |
-| **Streaming** | Decode as data arrives |
-| **Cropping/Scaling** | Decode to any size |
-| **YUV Support** | Direct YUV420 input/output |
-| **Content Presets** | Optimized settings for photos, drawings, icons, text |
-| **Resource Limits** | `Limits` policy: per-frame & cumulative pixel caps, frame count, metadata size, ... |
-| **Cancellation** | Cooperative cancellation via [`enough`](https://docs.rs/enough) crate |
-
-## Examples
-
-### Basic Encoding
-
-```rust
-use webpx::{Encoder, Unstoppable};
-
-// Lossy encoding (quality 0-100)
-let webp = Encoder::new_rgba(&rgba_data, 640, 480)
-    .quality(85.0)
-    .encode(Unstoppable)?;
-
-// Lossless encoding (exact pixels)
-let webp = Encoder::new_rgba(&rgba_data, 640, 480)
-    .lossless(true)
-    .encode(Unstoppable)?;
-
-// RGB without alpha
-let webp = Encoder::new_rgb(&rgb_data, 640, 480)
-    .quality(85.0)
-    .encode(Unstoppable)?;
-```
-
-### Builder API with Options
-
-```rust
-use webpx::{Encoder, Preset, Unstoppable};
-
-let webp = Encoder::new_rgba(&rgba_data, 640, 480)
-    .preset(Preset::Photo)    // Content-aware optimization
-    .quality(90.0)            // Higher quality
-    .method(5)                // Better compression (slower)
-    .alpha_quality(95)        // High-quality alpha
-    .sharp_yuv(true)          // Better color accuracy
-    .encode(Unstoppable)?;
-```
-
-### Advanced Configuration
-
-```rust
-use webpx::EncoderConfig;
-
-// Maximum compression (slow but smallest files)
-let config = EncoderConfig::max_compression();
-let webp = config.encode_rgba(&data, width, height)?;
-
-// Maximum quality lossless
-let config = EncoderConfig::max_compression_lossless();
-let webp = config.encode_rgba(&data, width, height)?;
-
-// Fine-grained control
-let config = EncoderConfig::new()
-    .quality(85.0)
-    .method(6)
-    .filter_strength(60)
-    .sns_strength(80)
-    .segments(4)
-    .pass(6)
-    .preprocessing(4);
-let (webp, stats) = config.encode_rgba_with_stats(&data, width, height)?;
-println!("PSNR: {:.2} dB, size: {} bytes", stats.psnr[4], stats.coded_size);
-```
-
-### Decoding with Processing
-
-```rust
-use webpx::Decoder;
-
-let decoder = Decoder::new(&webp_data)?;
-
-// Get image info without decoding
-let info = decoder.info();
-println!("{}x{}, alpha: {}", info.width, info.height, info.has_alpha);
-
-// Decode with cropping and scaling
-let (pixels, w, h) = decoder
-    .crop(100, 100, 400, 300)  // Extract region
-    .scale(200, 150)           // Resize
     .decode_rgba_raw()?;
+# Ok::<(), webpx::At<webpx::Error>>(())
 ```
 
-### Animation
+For animations, `max_total_pixels` bounds the cumulative `W × H × frame_count` (a 1000×1000 × 200-frame file is 200 MP cumulative even when each frame fits a per-frame `max_pixels` cap), and `max_animation_ms` bounds the summed frame timestamps. Field naming matches `zencodec::ResourceLimits`, so a single shared policy carries cleanly between Imazen codecs.
 
-```rust
-use webpx::{AnimationEncoder, AnimationDecoder, ColorMode, Limits};
+### Cooperative cancellation
 
-// Create animated WebP
-let mut encoder = AnimationEncoder::new(320, 240)?;
-encoder.set_quality(80.0);
-encoder.set_lossless(false);
-
-encoder.add_frame_rgba(&frame1_rgba, 0)?;     // Start at 0ms
-encoder.add_frame_rgba(&frame2_rgba, 100)?;   // Show at 100ms
-encoder.add_frame_rgba(&frame3_rgba, 200)?;   // Show at 200ms
-let webp = encoder.finish(300)?;              // End timestamp
-
-// Decode animation. Use `with_options_limits` if the input is
-// untrusted — `max_total_pixels` covers the W × H × frame_count
-// case (a 1000×1000 × 200-frame animation has 200 MP cumulative
-// even when each frame fits a per-frame `max_pixels` cap).
-let limits = Limits::none()
-    .with_max_pixels(64 * 1024 * 1024)
-    .with_max_total_pixels(256 * 1024 * 1024)
-    .with_max_frames(1024)
-    .with_max_animation_ms(60_000)            // 60 s of animation
-    .with_max_input_bytes(64 * 1024 * 1024);  // 64 MB bitstream
-let mut decoder = AnimationDecoder::with_options_limits(
-    &webp, ColorMode::Rgba, true, &limits,
-)?;
-let info = decoder.info();
-println!("{} frames, {}x{}", info.frame_count, info.width, info.height);
-
-// Iterate frames
-while let Some(frame) = decoder.next_frame()? {
-    render(&frame.data, frame.timestamp_ms);
-}
-
-// Or get all at once (this also enforces `max_animation_ms` against
-// the cumulative timestamp).
-decoder.reset();
-let frames = decoder.decode_all()?;
-```
-
-### ICC Profiles & Metadata
-
-```rust
-use webpx::{embed_icc, get_icc_profile_with_limits, embed_exif, get_exif_with_limits, Limits};
-
-// Embed ICC profile
-let webp_with_icc = embed_icc(&webp_data, &srgb_profile)?;
-
-// Extract — apply `max_metadata_bytes` to bound the ICCP/EXIF/XMP
-// chunk size even if the bitstream declares it as huge. Without
-// limits, an internal 256 MiB hard cap still applies.
-let limits = Limits::none().with_max_metadata_bytes(4 * 1024 * 1024);
-if let Some(icc) = get_icc_profile_with_limits(&webp_data, &limits)? {
-    println!("ICC profile: {} bytes", icc.len());
-}
-
-// EXIF data
-let webp_with_exif = embed_exif(&webp_data, &exif_bytes)?;
-if let Some(exif) = get_exif_with_limits(&webp_data, &limits)? {
-    // Parse EXIF...
-}
-```
-
-### Streaming Decode
-
-```rust
-use webpx::{StreamingDecoder, DecodeStatus, ColorMode};
-
-let mut decoder = StreamingDecoder::new(ColorMode::Rgba)?;
-
-// Feed data as it arrives
-for chunk in network_stream {
-    match decoder.append(&chunk)? {
-        DecodeStatus::Complete => break,
-        DecodeStatus::NeedMoreData => continue,
-        DecodeStatus::Partial(rows) => {
-            // Progressive display
-            if let Some((data, w, h)) = decoder.get_partial() {
-                display_partial(data, w, h);
-            }
-        }
-        _ => {} // Handle future variants
-    }
-}
-
-let (pixels, width, height) = decoder.finish()?;
-```
-
-### Cooperative Cancellation
-
-Encoding can be cancelled cooperatively using the [`enough`](https://docs.rs/enough) crate:
+Encoding accepts any [`enough::Stop`](https://docs.rs/enough) implementation; pass `Unstoppable` to disable it. libwebp calls back into the `Stop` during the encode, so a flagged cancellation aborts mid-work and surfaces as `Error::Stopped`.
 
 ```rust
 use webpx::{Encoder, Error, StopReason};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-// Create a cancellation flag
-let cancelled = Arc::new(AtomicBool::new(false));
-let flag = cancelled.clone();
-
-// Custom Stop implementation
-struct MyCanceller(Arc<AtomicBool>);
-impl enough::Stop for MyCanceller {
+struct Canceller(Arc<AtomicBool>);
+impl enough::Stop for Canceller {
     fn check(&self) -> Result<(), enough::StopReason> {
         if self.0.load(Ordering::Relaxed) {
             Err(enough::StopReason::Cancelled)
@@ -304,133 +103,256 @@ impl enough::Stop for MyCanceller {
     }
 }
 
-// In another thread: flag.store(true, Ordering::Relaxed);
+let cancelled = Arc::new(AtomicBool::new(false));
+// ... another thread: cancelled.store(true, Ordering::Relaxed);
 
 match Encoder::new_rgba(&data, width, height)
     .quality(85.0)
-    .encode(MyCanceller(cancelled))
+    .encode(Canceller(cancelled))
 {
-    Ok(webp) => { /* success */ },
-    Err(Error::Stopped(StopReason::Cancelled)) => { /* cancelled */ },
-    Err(e) => { /* other error */ },
+    Ok(webp) => { /* success */ }
+    Err(Error::Stopped(StopReason::Cancelled)) => { /* aborted */ }
+    Err(e) => { /* other error */ }
 }
+# Ok::<(), webpx::At<webpx::Error>>(())
 ```
 
-For ready-to-use cancellation primitives (timeouts, channels, etc.), see the [`almost-enough`](https://docs.rs/almost-enough) crate.
+For ready-made cancellation primitives (timeouts, channels), see [`almost-enough`](https://docs.rs/almost-enough).
 
-## Feature Flags
+## More examples
 
-| Feature | Default | Description |
-|---------|---------|-------------|
-| `decode` | Yes | WebP decoding |
-| `encode` | Yes | WebP encoding |
-| `std` | Yes | Use std (disable for no_std + alloc) |
-| `animation` | No | Animated WebP support |
-| `icc` | No | ICC/EXIF/XMP metadata |
-| `streaming` | No | Incremental decode/encode |
-
-```toml
-# All features
-webpx = { version = "0.1", features = ["animation", "icc", "streaming"] }
-
-# no_std
-webpx = { version = "0.1", default-features = false, features = ["decode", "encode"] }
-```
-
-## Content Presets
-
-Choose a preset to optimize for your content type:
-
-| Preset | Best For | Characteristics |
-|--------|----------|-----------------|
-| `Default` | General use | Balanced settings |
-| `Photo` | Photographs | Better color, outdoor scenes |
-| `Picture` | Indoor/portraits | Skin tone optimization |
-| `Drawing` | Line art | High contrast, sharp edges |
-| `Icon` | Small images | Color preservation |
-| `Text` | Screenshots | Crisp text rendering |
+### Encoder builder
 
 ```rust
 use webpx::{Encoder, Preset, Unstoppable};
 
-let webp = Encoder::new_rgba(&data, w, h)
-    .preset(Preset::Photo)
+// Lossless: exact pixels.
+let webp = Encoder::new_rgba(&rgba, 640, 480)
+    .lossless(true)
     .encode(Unstoppable)?;
+
+// Tuned lossy with a content preset.
+let webp = Encoder::new_rgba(&rgba, 640, 480)
+    .preset(Preset::Photo)   // content-aware optimization
+    .quality(90.0)
+    .method(5)               // 0-6: higher = slower, smaller
+    .alpha_quality(95)       // 0-100 alpha-plane quality
+    .sharp_yuv(true)         // sharper RGB->YUV conversion
+    .encode(Unstoppable)?;
+
+// RGB input (no alpha).
+let webp = Encoder::new_rgb(&rgb, 640, 480)
+    .quality(85.0)
+    .encode(Unstoppable)?;
+# Ok::<(), webpx::At<webpx::Error>>(())
 ```
 
-## Platform Support
+### EncoderConfig with statistics
+
+```rust
+use webpx::EncoderConfig;
+
+// Presets for the common extremes.
+let webp = EncoderConfig::max_compression().encode_rgba(&data, width, height)?;
+let webp = EncoderConfig::max_compression_lossless().encode_rgba(&data, width, height)?;
+
+// Fine-grained control, with PSNR/size stats.
+let config = EncoderConfig::new()
+    .quality(85.0)
+    .method(6)
+    .filter_strength(60)
+    .sns_strength(80)
+    .segments(4)
+    .pass(6)
+    .preprocessing(4);
+let (webp, stats) = config.encode_rgba_with_stats(&data, width, height)?;
+println!("PSNR {:.2} dB, {} bytes", stats.psnr[4], stats.coded_size);
+# Ok::<(), webpx::At<webpx::Error>>(())
+```
+
+### Decoding with cropping & scaling
+
+```rust
+use webpx::Decoder;
+
+let decoder = Decoder::new(&webp_data)?;
+
+// Inspect dimensions without decoding pixels.
+let info = decoder.info();
+println!("{}x{}, alpha: {}", info.width, info.height, info.has_alpha);
+
+// Extract a region, then resize it.
+let (pixels, w, h) = decoder
+    .crop(100, 100, 400, 300)
+    .scale(200, 150)
+    .decode_rgba_raw()?;
+# Ok::<(), webpx::At<webpx::Error>>(())
+```
+
+### Animation (`animation` feature)
+
+```rust
+use webpx::{AnimationEncoder, AnimationDecoder, ColorMode, Limits};
+
+// Encode an animated WebP. Timestamps are the show time of each frame in ms.
+let mut encoder = AnimationEncoder::new(320, 240)?;
+encoder.set_quality(80.0);
+encoder.set_lossless(false);
+encoder.add_frame_rgba(&frame0, 0)?;
+encoder.add_frame_rgba(&frame1, 100)?;
+encoder.add_frame_rgba(&frame2, 200)?;
+let webp = encoder.finish(300)?; // end timestamp
+
+// Decode with limits when the input is untrusted.
+let limits = Limits::default()
+    .with_max_frames(1024)
+    .with_max_animation_ms(60_000);
+let mut decoder =
+    AnimationDecoder::with_options_limits(&webp, ColorMode::Rgba, true, &limits)?;
+let total = decoder.info().frame_count;
+while let Some(frame) = decoder.next_frame()? {
+    render(&frame.data, frame.timestamp_ms);
+}
+# fn render(_: &[u8], _: i32) {}
+# Ok::<(), webpx::At<webpx::Error>>(())
+```
+
+### ICC profiles & metadata (`icc` feature)
+
+```rust
+use webpx::{embed_icc, get_icc_profile_with_limits, embed_exif, Limits};
+
+// Embed an ICC profile (returns a new, larger WebP).
+let with_icc = embed_icc(&webp_data, &srgb_profile)?;
+
+// Extract — bound the metadata chunk even if the bitstream declares it huge.
+let limits = Limits::default().with_max_metadata_bytes(4 * 1024 * 1024);
+if let Some(icc) = get_icc_profile_with_limits(&with_icc, &limits)? {
+    println!("ICC profile: {} bytes", icc.len());
+}
+
+// EXIF works the same way (embed_exif / get_exif_with_limits), as does XMP.
+let _with_exif = embed_exif(&webp_data, &exif_bytes)?;
+# Ok::<(), webpx::At<webpx::Error>>(())
+```
+
+### Streaming decode (`streaming` feature)
+
+```rust
+use webpx::{StreamingDecoder, DecodeStatus, ColorMode};
+
+let mut decoder = StreamingDecoder::new(ColorMode::Rgba)?;
+for chunk in network_stream {
+    match decoder.append(&chunk)? {
+        DecodeStatus::Complete => break,
+        DecodeStatus::NeedMoreData => continue,
+        DecodeStatus::Partial(_rows) => {
+            if let Some((data, w, h)) = decoder.get_partial() {
+                display_partial(data, w, h); // progressive preview
+            }
+        }
+        _ => {}
+    }
+}
+let (pixels, width, height) = decoder.finish()?;
+# fn display_partial(_: &[u8], _: u32, _: u32) {}
+# let network_stream: Vec<Vec<u8>> = Vec::new();
+# Ok::<(), webpx::At<webpx::Error>>(())
+```
+
+`StreamingDecoder` checks `max_input_bytes` against the cumulative fed bytes and the dimension/pixel caps against the canvas as soon as the header prefix arrives — before libwebp allocates the output.
+
+## Key types
+
+| Type | Role |
+|------|------|
+| `Encoder` | Lossy/lossless encode builder (`new_rgba` / `new_rgb` / `new_bgra` / `new_bgr` / `new_yuv` + `_stride` variants). |
+| `EncoderConfig` | Reusable encode configuration with `encode_rgba` / `encode_rgba_with_stats` and `EncodeStats`. |
+| `Decoder` | Decode builder with `crop` / `scale` / `config` and typed/raw/zero-copy output methods. |
+| `decode_rgba` / `decode_rgb` / `decode_bgra` / `decode_bgr` | One-call decode free functions returning `(Vec<u8>, width, height)`. |
+| `Limits` | Resource policy enforced on every decode path; `default()` (production caps) or `none()` (trusted input). |
+| `Preset` | Content presets: `Default`, `Photo`, `Picture`, `Drawing`, `Icon`, `Text`. |
+| `AnimationEncoder` / `AnimationDecoder` | Multi-frame WebP encode/decode (`animation` feature). |
+| `StreamingDecoder` / `StreamingEncoder` | Incremental processing (`streaming` feature). |
+| `embed_icc` / `get_icc_profile_with_limits` (+ EXIF/XMP) | Metadata mux/demux (`icc` feature). |
+| `Error`, `At<Error>` | Error type with lightweight location tracking via [`whereat`](https://docs.rs/whereat). |
+| `Stop`, `Unstoppable`, `StopReason` | Cooperative cancellation, re-exported from [`enough`](https://docs.rs/enough). |
+
+Errors are returned as `Result<T, At<Error>>`, where `At` records the source location for traceability. Propagate with `.at()`, attach your crate's info with `at_crate!`, and recover the plain error with `.into_inner()`.
+
+## Features
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `decode` | yes | WebP decoding. |
+| `encode` | yes | WebP encoding. |
+| `std` | yes | Standard library; disable for `no_std` + `alloc`. |
+| `animation` | no | Animated WebP encode/decode. |
+| `icc` | no | ICC / EXIF / XMP metadata mux. |
+| `streaming` | no | Incremental decode/encode. |
+| `zencodec` | no | [`zencodec`](https://docs.rs/zencodec) trait implementations (mirrors `zenwebp`'s surface for drop-in interchange). |
+
+### `no_std`
+
+`webpx` builds on `no_std` + `alloc`. Disable the `std` feature:
+
+```toml
+[dependencies]
+webpx = { version = "0.4.0", default-features = false, features = ["decode", "encode"] }
+```
+
+(The underlying libwebp still requires a C toolchain at build time.)
+
+## Content presets
+
+| Preset | Best for |
+|--------|----------|
+| `Default` | General use, balanced settings. |
+| `Photo` | Photographs, outdoor scenes. |
+| `Picture` | Indoor shots and portraits. |
+| `Drawing` | Line art, high-contrast edges. |
+| `Icon` | Small images, color preservation. |
+| `Text` | Screenshots, crisp text. |
+
+## Migration shims
+
+Drop-in compatibility modules ease porting from existing crates — change the import, keep your code:
+
+```rust
+// From the `webp` crate:
+use webpx::compat::webp::{Encoder, Decoder};
+
+// From the `webp-animation` crate (uses `finalize()` to match its API):
+use webpx::compat::webp_animation::{Encoder, Decoder};
+```
+
+## Platform support
 
 | Platform | Status |
 |----------|--------|
-| Linux x64/ARM64 | ✅ Full support |
-| macOS x64/ARM64 | ✅ Full support |
-| Windows x64/ARM64 | ✅ Full support |
-| WebAssembly (emscripten) | ✅ Supported |
-| WebAssembly (wasm32-unknown-unknown) | ❌ Not supported (use [`zenwebp`](https://github.com/imazen/zenwebp), which is native to this target) |
-| MIPS / MIPS DSP | ✅ Inherits libwebp's hand-tuned DSP-R2 paths |
+| Linux, macOS, Windows (x64 / ARM64) | Supported. |
+| WebAssembly (`wasm32-unknown-emscripten`) | Supported (requires emscripten, since libwebp is C). |
+| MIPS / MIPS DSP | Inherits libwebp's hand-tuned DSP-R2 paths. |
 
-### Building for WebAssembly
+For a native `wasm32-unknown-unknown` build without a C toolchain, use [`zenwebp`](https://github.com/imazen/zenwebp).
 
-```bash
-# Install emscripten
-git clone https://github.com/emscripten-core/emsdk.git ~/emsdk
-cd ~/emsdk && ./emsdk install latest && ./emsdk activate latest
+## Minimum supported Rust version
 
-# Add target and build
-rustup target add wasm32-unknown-emscripten
-source ~/emsdk/emsdk_env.sh
-cargo build --target wasm32-unknown-emscripten --release
-```
-
-## Migration from Other Crates
-
-### From `webp` crate
-
-```rust
-// Before
-use webp::{Encoder, Decoder};
-
-// After - use compat shim
-use webpx::compat::webp::{Encoder, Decoder};
-// API is compatible, just change the import
-```
-
-### From `webp-animation` crate
-
-```rust
-// Before
-use webp_animation::{Encoder, Decoder};
-
-// After - use compat shim
-use webpx::compat::webp_animation::{Encoder, Decoder};
-// Uses finalize() instead of finish() to match original API
-```
-
-## Performance Tips
-
-1. **Use appropriate `method`** - Higher values (4-6) give better compression but are slower
-2. **Choose the right preset** - Presets tune internal parameters for content type
-3. **Consider `sharp_yuv`** - Better color accuracy at slight speed cost
-4. **Batch frames** - For animations, encode multiple frames before finalizing
-5. **Pre-allocate buffers** - Use `StreamingDecoder::with_buffer()` to avoid allocations
-
-## Minimum Supported Rust Version
-
-Rust 1.80 or later.
+Rust 1.89 or later.
 
 ## License
 
 Licensed under either of:
 
-- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+- Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or <http://opensource.org/licenses/MIT>)
 
 at your option.
 
 ## Contributing
 
-Contributions welcome! Please open issues and pull requests on [GitHub](https://github.com/imazen/webpx).
+Issues and pull requests are welcome on [GitHub](https://github.com/imazen/webpx).
 
-## AI-Generated Code Notice
+## AI-generated code notice
 
-This crate was developed with assistance from Claude (Anthropic). Not all code has been manually reviewed. Please review critical paths before production use.
+This crate was developed with assistance from Claude (Anthropic). Not all code has been manually reviewed; review critical paths before production use.


### PR DESCRIPTION
## What

Rewrites the crate README to be accurate, factual, and on-its-own-terms.

The published crate's README had drifted: it carried a large "use a different crate instead" section plus libwebp/webpx security framing that read as disparagement, stale install versions (`"0.2"` / `"0.1"` against the current `0.4.0`), a wrong MSRV (`1.80` vs the actual `1.89` in `Cargo.toml`), and GitHub/codecov-native badges rather than the standard `?style=flat-square` shields.io set.

## Changes

- **Factual framing** — presents `webpx` on its own merits (ergonomic FFI bindings to libwebp; lossy/lossless, animation, ICC/EXIF/XMP, streaming, `no_std`). The pure-Rust sibling `zenwebp` is mentioned once as a neutral pointer for the `wasm32-unknown-unknown` case, with no disparagement of either crate.
- **Verified quick-start** — copy-pasteable decode (`decode_rgba`: WebP -> RGBA) and encode (`Encoder::new_rgba(...).quality(..).encode(Unstoppable)`) examples; states the 8-bit interleaved R,G,B,A pixel order both sides use.
- **Server-safety section** — documents the `Limits` resource policy (enforced on every decode path; `default()` production caps vs `none()` opt-out) and cooperative cancellation via `enough::Stop` — the highest-value content for a codec handling untrusted uploads.
- **Key types + Features tables**, content presets, migration shims (`compat::webp` / `compat::webp_animation`), `no_std` note, platform support.
- Badges switched to inline `?style=flat-square` shields.io (CI, crates.io, lib.rs, docs.rs, license); install versions corrected to `0.4.0`; MSRV corrected to `1.89`.
- Set `readme = "README.md"` in `Cargo.toml` (was relying on Cargo's implicit pickup).
- CHANGELOG `[Unreleased]/Added` entry.

## Verification

Every documented symbol was checked against `src/` (decode/encode entry points, `Limits` builders, `DecoderConfig`, `EncoderConfig`, `Preset` variants, animation/streaming/mux APIs, `EncodeStats` fields). Markdown-only change; no doctest wiring added to the crate.