### PR TITLE
test(heaptrack): add a decode allocation-profiling harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@
 
 ### Added
 
+- `examples/heaptrack_decode.rs`: a reusable heaptrack/valgrind harness that
+  decodes a WebP from bytes via `webpx::decode_rgba(..)` in a loop, for profiling
+  heap-allocation behaviour. Defaults to the committed `tests/fixtures/lossy_rgb.webp`
+  (100×100 lossy VP8) decoded 8×; a path + iteration count can be passed. Driven by
+  `just heaptrack-decode`. Complements the existing `alloc_profile` example (which
+  single-shots a mix of encode+decode methods) by isolating the decode-from-bytes
+  path in a loop so a per-decode leak shows as growth. Profiled result is **healthy**:
+  ~5 allocations per decode and the allocation count is **size-invariant** (56 total
+  allocs for 100×100 vs 57 for 1024×1024 — libwebp allocates a handful of large
+  O(image) buffers in `WebPAllocateDecBuffer` / `VP8InitFrame`, not per-macroblock),
+  peak heap 156.7 KiB for the 100×100 fixture (O(image)), and the leaked count is
+  pinned at 1 process static across 2/8/16 iterations (no per-decode leak, no churn).
 - `docs(readme)`: rewrote the README — decode/encode quick-start, server-safety section (`Limits` + cooperative cancellation), key-types and features tables, factual on-its-own-terms framing, `?style=flat-square` badges, and `readme = "README.md"` in `Cargo.toml`. Fixed stale install versions (now `0.4.0`) and MSRV (`1.89`).
 
 ## [0.4.0] - 2026-06-10

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,3 +117,8 @@ required-features = ["encode", "decode", "streaming", "animation", "icc"]
 [[example]]
 name = "zencodec_swap"
 required-features = ["zencodec"]
+
+# Heaptrack allocation-profiling harness for the decode-from-bytes path.
+[[example]]
+name = "heaptrack_decode"
+required-features = ["decode"]

--- a/examples/heaptrack_decode.rs
+++ b/examples/heaptrack_decode.rs
@@ -1,0 +1,104 @@
+//! Heaptrack harness for WebP decode-from-bytes allocation profiling.
+//!
+//! Profiles the production-critical path: `webpx::decode_rgba(&bytes)` — decoding a
+//! WebP file (untrusted input) all the way to interleaved RGBA8 pixels. The goal is
+//! to surface allocation *pathologies* that don't show up in a wall-clock benchmark:
+//! a high allocation *count* relative to image size, per-pixel or per-macroblock-row
+//! mallocs, large transient peaks, or unbounded growth across repeated decodes (a
+//! leak). High allocation churn hurts most under contended allocators (Windows,
+//! multi-threaded servers) where a single decode of an untrusted upload turns into
+//! many allocator lock round-trips.
+//!
+//! NOTE: webpx is a thin safe wrapper over `libwebp` via `libwebp-sys` (C FFI), so
+//! the bulk of the allocation call-sites originate inside libwebp's C decoder
+//! (`WebPDecode`); webpx owns the RAII resource wrappers and the output `Vec`. The
+//! report below notes that the allocations are libwebp's, not Rust-side churn.
+//! heaptrack captures the C `malloc`s too.
+//!
+//! This complements the existing `examples/alloc_profile.rs` (which single-shots a
+//! mix of encode + decode methods on a synthesized image): this harness decodes a
+//! committed fixture from bytes in a *loop*, so a per-decode leak shows up as
+//! monotonic growth across iterations.
+//!
+//! Usage:
+//!   cargo build --release --example heaptrack_decode
+//!   heaptrack ./target/release/examples/heaptrack_decode                 # default fixture
+//!   heaptrack ./target/release/examples/heaptrack_decode <file.webp> [iters]
+//!
+//! Then inspect:
+//!   heaptrack_print heaptrack.heaptrack_decode.*.zst | less
+//!
+//! Defaults to the committed `tests/fixtures/lossy_rgb.webp` (100x100 lossy VP8)
+//! decoded 8 times. Pass a larger WebP to judge the allocation count against a
+//! bigger macroblock grid; a large fixture should be decoded fewer times (pass a
+//! smaller `iters`).
+
+use std::hint::black_box;
+use std::path::{Path, PathBuf};
+
+/// Resolve the default bundled fixture relative to the crate manifest so the
+/// example runs from any working directory.
+fn default_fixture() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/lossy_rgb.webp")
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+
+    let path: PathBuf = match args.get(1) {
+        Some(p) => PathBuf::from(p),
+        None => default_fixture(),
+    };
+    // Default 8 iterations; a leak shows up as monotonic growth across them, and a
+    // healthy decoder's steady-state per-decode allocation count is iterations-stable.
+    let iters: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(8);
+
+    let data = std::fs::read(&path).unwrap_or_else(|e| {
+        eprintln!("failed to read {}: {e}", path.display());
+        std::process::exit(1);
+    });
+
+    // Probe once so the report can state the dimensions the alloc count is relative to.
+    match webpx::ImageInfo::from_webp(&data) {
+        Ok(info) => {
+            eprintln!("fixture: {} ({} bytes on disk)", path.display(), data.len());
+            eprintln!(
+                "  decoded image: {}x{} ({:.2} MP), alpha {}, format {:?}",
+                info.width,
+                info.height,
+                (f64::from(info.width) * f64::from(info.height)) / 1.0e6,
+                info.has_alpha,
+                info.format,
+            );
+            eprintln!(
+                "  RGBA8 output buffer: {} bytes",
+                u64::from(info.width) * u64::from(info.height) * 4
+            );
+        }
+        Err(e) => {
+            eprintln!(
+                "probe (ImageInfo::from_webp) failed for {}: {e}",
+                path.display()
+            );
+            std::process::exit(1);
+        }
+    }
+
+    eprintln!("decoding {iters}x via webpx::decode_rgba(..) ...");
+
+    let mut total_pixels: u64 = 0;
+    for i in 0..iters {
+        let (pixels, w, h) = webpx::decode_rgba(&data).unwrap_or_else(|e| {
+            eprintln!("decode iteration {i} failed: {e}");
+            std::process::exit(1);
+        });
+        total_pixels += u64::from(w) * u64::from(h);
+        // Consume the decoded buffer so the optimizer can't elide the decode or the
+        // allocation of the output Vec.
+        black_box(&pixels);
+        black_box(w);
+        black_box(h);
+    }
+
+    eprintln!("done: decoded {total_pixels} total pixels across {iters} iterations");
+}

--- a/justfile
+++ b/justfile
@@ -55,6 +55,15 @@ mem-profile:
 mem-profile-print:
     heaptrack_print heaptrack.alloc_profile.*.zst | head -150
 
+# Profile the decode-from-bytes path specifically (decode a committed fixture in a
+# loop). Complements `mem-profile` (which single-shots encode+decode methods).
+# Defaults to tests/fixtures/lossy_rgb.webp decoded 8x; pass a path + iters to override.
+# Inspect with: heaptrack_print /tmp/webpx-ht.zst
+heaptrack-decode *ARGS:
+    cargo build --release --example heaptrack_decode --features decode
+    rm -f /tmp/webpx-ht.zst
+    heaptrack --output /tmp/webpx-ht ./target/release/examples/heaptrack_decode {{ARGS}}
+
 # Quick memory profiler (without heaptrack, just RSS tracking)
 mem-profile-quick:
     cargo run --release --all-features --example alloc_profile


### PR DESCRIPTION
Adds a reusable `examples/heaptrack_decode.rs` for profiling the **decode-from-untrusted-bytes** heap-allocation behaviour under heaptrack/valgrind, mirroring the harness now in `heic`/`zenjpeg`/`zenpng`. It decodes a WebP via the public `webpx::decode_rgba(..)` in a loop (default 8x), accepts a `<path> [iters]` override, and is driven by `just heaptrack-decode`.

This complements the existing `examples/alloc_profile.rs` (which single-shots a mix of encode + decode methods on a synthesized image) by isolating the **decode-from-bytes path in a loop**, so a per-decode leak shows up as monotonic growth across iterations and the per-decode allocation count is directly measurable.

Default fixture: the committed `tests/fixtures/lossy_rgb.webp` (100x100 lossy VP8).

## Profiled result (heaptrack 1.3.0, release, no target-cpu=native) — HEALTHY

| metric | 100×100 fixture | 1024×1024 (1 MP) | note |
|---|---|---|---|
| total alloc count | **56** | **57** | **size-invariant** — not per-macroblock |
| per-decode count | ~5 | ~5 | from 27 @ 2 iters -> 97 @ 16 iters |
| peak heap | 156.7 KiB | (O(image)) | the RGBA output + libwebp scratch |
| leaked | 1 alloc / 544 B | 1 alloc | one process static, iteration-stable |
| temporary allocs | 2 | 1 | negligible |

**This is the gold-standard shape for a C-FFI decoder.** The allocation count is essentially independent of image dimensions (56 allocs for 100×100 vs 57 for 1024×1024), because libwebp allocates a handful of large O(image) buffers per decode rather than per-macroblock or per-row. Per-decode steady state is ~5 allocations.

The dominant call-sites are all libwebp C functions — `WebPAllocateDecBuffer`, `VP8InitFrame`, `VP8New`, `CustomSetup` — i.e. the decoder's YUV-plane / output-buffer setup. heaptrack captures these C `malloc`s.

**No leak.** Leaked-allocation count is exactly 1 at 2, 8, and 16 iterations (one process static — the documented ~544 B thread-local), no per-decode growth, no churn. No issue filed; recorded as a baseline.

run-heavy: build peak-RSS 0.64 GiB / min-avail 49684 MiB; heaptrack run peak-RSS 0.12 GiB / min-avail 51280 MiB.
