### PR TITLE
docs(webpx): add the default-limits note to the 5 byte-level decode fns (match the crate's blanket claim)

### DIFF
--- a/src/decode.rs
+++ b/src/decode.rs
@@ -418,6 +418,10 @@ pub(crate) fn decode_into_unlimited<P: DecodePixel>(
 /// This function decodes directly into the provided buffer, avoiding
 /// allocation and copy overhead.
 ///
+/// Applies webpx's default resource limits ([`crate::Limits::default`]).
+/// To decode trusted input without caps, use [`Decoder`] with
+/// [`Limits::none()`](crate::Limits::none).
+///
 /// # Arguments
 /// * `data` - WebP encoded data
 /// * `output` - Pre-allocated output buffer (must be at least stride * height bytes)
@@ -494,6 +498,10 @@ pub(crate) fn decode_rgba_into_unlimited(
 ///
 /// BGRA is the native format on Windows and some GPU APIs.
 ///
+/// Applies webpx's default resource limits ([`crate::Limits::default`]).
+/// To decode trusted input without caps, use [`Decoder`] with
+/// [`Limits::none()`](crate::Limits::none).
+///
 /// # Arguments
 /// * `data` - WebP encoded data
 /// * `output` - Pre-allocated output buffer (must be at least stride * height bytes)
@@ -557,6 +565,10 @@ pub(crate) fn decode_bgra_into_unlimited(
 }
 
 /// Decode WebP data directly into a pre-allocated RGB buffer (zero-copy).
+///
+/// Applies webpx's default resource limits ([`crate::Limits::default`]).
+/// To decode trusted input without caps, use [`Decoder`] with
+/// [`Limits::none()`](crate::Limits::none).
 ///
 /// # Arguments
 /// * `data` - WebP encoded data
@@ -624,6 +636,10 @@ pub(crate) fn decode_rgb_into_unlimited(
 ///
 /// BGR is common in OpenCV and some image libraries.
 ///
+/// Applies webpx's default resource limits ([`crate::Limits::default`]).
+/// To decode trusted input without caps, use [`Decoder`] with
+/// [`Limits::none()`](crate::Limits::none).
+///
 /// # Arguments
 /// * `data` - WebP encoded data
 /// * `output` - Pre-allocated output buffer (must be at least stride * height bytes)
@@ -689,6 +705,10 @@ pub(crate) fn decode_bgr_into_unlimited(
 /// Decode WebP data to YUV planes.
 ///
 /// Returns YUV420 planar data.
+///
+/// Applies webpx's default resource limits ([`crate::Limits::default`]).
+/// To decode trusted input without caps, use [`Decoder`] with
+/// [`Limits::none()`](crate::Limits::none).
 pub fn decode_yuv(data: &[u8]) -> Result<YuvPlanes> {
     default_limits_gate(data)?;
     decode_yuv_unlimited(data)


### PR DESCRIPTION
Doc-only, non-breaking. Closes a documentation coverage gap.

`src/lib.rs` (lines 70-77) promises that *'every decode-side entry point enforces [`Limits::default()`] unless you opt out'*. The 5 byte-level free decode fns all call `default_limits_gate(data)?` (so the claim is true), but they carried **no rustdoc note** saying so — unlike the typed free fns (`decode_rgba`, `decode_into`, etc.) which already carry it:

| fn | line |
|----|------|
| `decode_rgba_into` | src/decode.rs:438 |
| `decode_bgra_into` | :504 |
| `decode_rgb_into`  | :568 |
| `decode_bgr_into`  | :634 |
| `decode_yuv`       | :692 |

Added the existing note verbatim to each (matching the wording already on the typed fns at src/decode.rs:45, :89, :126, …):

```
Applies webpx's default resource limits ([`crate::Limits::default`]).
To decode trusted input without caps, use [`Decoder`] with
[`Limits::none()`](crate::Limits::none).
```

15 added `///` lines, no code, no signature, no behavior change. CI verifies.