### PR TITLE
fix(error): preserve zenpixels At trace via map_err_at (no more stringify/flatten)

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -25,7 +25,7 @@ use alloc::format;
 use alloc::sync::Arc;
 use alloc::vec::Vec;
 
-use whereat::{At, at};
+use whereat::{At, ResultAtExt, at};
 use zencodec::decode::{DecodeOutput, DecodeRowSink, OutputInfo};
 use zencodec::encode::EncodeOutput;
 use zencodec::{
@@ -921,7 +921,7 @@ impl zencodec::decode::Decode for WebpDecoder<'_> {
         };
 
         let buf = PixelBuffer::from_vec(bytes, w, h, descriptor)
-            .map_err(|e| at!(Error::InvalidInput(format!("{e:?}"))))?;
+            .map_err_at(|inner| Error::InvalidInput(format!("{inner:?}")))?;
         let info = ImageInfo::new(w, h, ImageFormat::WebP).with_alpha(descriptor.has_alpha());
         Ok(DecodeOutput::new(buf, info))
     }
@@ -970,7 +970,7 @@ impl zencodec::decode::StreamingDecode for WebpStreamingDecoder {
         let (bytes, w, h) = self.decoded.as_ref().unwrap();
         let stride_bytes = (*w as usize).saturating_mul(self.descriptor.bytes_per_pixel());
         let slice = PixelSlice::new(bytes, *w, *h, stride_bytes, self.descriptor)
-            .map_err(|e| at!(Error::InvalidInput(format!("{e:?}"))))?;
+            .map_err_at(|inner| Error::InvalidInput(format!("{inner:?}")))?;
         Ok(Some((0, slice)))
     }
 
@@ -1051,7 +1051,7 @@ impl zencodec::decode::AnimationFrameDecoder for WebpAnimationFrameDecoder {
             stride_bytes,
             self.descriptor,
         )
-        .map_err(|e| at!(Error::InvalidInput(format!("{e:?}"))))?;
+        .map_err_at(|inner| Error::InvalidInput(format!("{inner:?}")))?;
         Ok(Some(zencodec::decode::AnimationFrame::new(
             slice,
             frame.duration_ms,


### PR DESCRIPTION
## Summary

Three sites in the `zencodec` decode adapter stringified `At<BufferError>` traces while wrapping zenpixels buffer construction into `At<Error>`. `PixelBuffer::from_vec` and `PixelSlice::new` both return `Result<_, At<BufferError>>` (the trace carrier), so the `format!("{e:?}")` on the `At` flattened the location trace and the surrounding `at!()` reset it.

| Site | Callee (returns `At<BufferError>`) |
|---|---|
| `src/codec.rs:924` | `PixelBuffer::from_vec(...)` |
| `src/codec.rs:973` | `PixelSlice::new(...)` |
| `src/codec.rs:1054` | `PixelSlice::new(...)` |

**Before:** `.map_err(|e| at!(Error::InvalidInput(format!("{e:?}"))))?`
**After:** `.map_err_at(|inner| Error::InvalidInput(format!("{inner:?}")))?`

The inner `BufferError` is bare (a plain enum), so the closure Debug-formats it for the same human-readable message while `map_err_at` carries the zenpixels `At` trace through. Added `ResultAtExt` to the `whereat` import.

## Verification (all GREEN, under run-heavy, no target-cpu=native)

- `cargo clippy --features zencodec --all-targets -- -D warnings` ✓
- `cargo test --features zencodec` ✓ (216 tests, 0 failed)
- `cargo build` (default features) ✓
- `cargo fmt --check` ✓ (no reformatting needed)

Built in an isolated jj workspace off `main@origin`; 1 file changed (4 lines).